### PR TITLE
Fix USD -> ETH conversion

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -88,6 +88,7 @@ export function toETH(amount, rate, errorValue = 'Invalid amount') {
   const expectedETHamount = isValidAmount
     ? weiAmount
         .dividedBy(new BigNumber(Web3.utils.toWei(String(rate))))
+        .decimalPlaces(18)
         .toString()
     : errorValue
 


### PR DESCRIPTION
This limits the USD to ETH conversion to 18 decimals to avoid returning "unweiable" amounts.

Closes #8