### PR TITLE
Disable converter during initial auction

### DIFF
--- a/src/components/Converter.js
+++ b/src/components/Converter.js
@@ -64,6 +64,7 @@ const AvailableAmount = styled.div`
 
 class Converter extends React.Component {
   static propTypes = {
+    isConverterEnabled: PropTypes.bool.isRequired,
     converterPriceUSD: PropTypes.string.isRequired,
     converterStatus: PropTypes.shape({
       availableEth: PropTypes.string.isRequired,
@@ -80,7 +81,11 @@ class Converter extends React.Component {
   onCloseModal = () => this.setState({ activeModal: null })
 
   render() {
-    const { converterPriceUSD, converterStatus } = this.props
+    const {
+      isConverterEnabled,
+      converterPriceUSD,
+      converterStatus
+    } = this.props
 
     return (
       <DarkLayout title="Autonomous Converter">
@@ -135,7 +140,11 @@ class Converter extends React.Component {
                 </StatsContainer>
               </Flex.Column>
               <Sp mt={4} ml={2}>
-                <Btn data-modal="convert" onClick={this.onOpenModal} disabled>
+                <Btn
+                  data-modal="convert"
+                  disabled={!isConverterEnabled}
+                  onClick={this.onOpenModal}
+                >
                   Convert
                 </Btn>
               </Sp>
@@ -161,6 +170,7 @@ class Converter extends React.Component {
 }
 
 const mapStateToProps = state => ({
+  isConverterEnabled: selectors.isConverterEnabled(state),
   converterPriceUSD: selectors.getConverterPriceUSD(state),
   converterStatus: selectors.getConverterStatus(state)
 })

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -117,7 +117,10 @@ export const getAuctionStatus = createSelector(
 
 export const getCurrentAuction = createSelector(
   getAuctionStatus,
-  auctionStatus => auctionStatus.currentAuction
+  auctionStatus =>
+    auctionStatus && auctionStatus.currentAuction
+      ? auctionStatus.currentAuction
+      : '-1'
 )
 
 export const getAuctionPriceUSD = createSelector(
@@ -245,4 +248,16 @@ export const hasEnoughData = createSelector(
     mtnBalance !== null &&
     ethRate !== null &&
     blockHeight !== null
+)
+
+export const isConverterEnabled = createSelector(
+  getCurrentAuction,
+  currentAuction => {
+    const isInDailyAuction = parseInt(currentAuction, 10) > 0
+
+    // TODO remove this when Converter Contract is working fine
+    const isConverterWorking = false
+
+    return isConverterWorking && isInDailyAuction
+  }
 )


### PR DESCRIPTION
"Convert" button will be disabled on the following scenarios:

  - Initial Auction is not started yet
  - Initial Auction is in progress
  - Converter Contract is set as "not working" (temporary fix while converter contract issues are being addressed)

Closes #57