### PR TITLE
Display a warning message when connectivity is lost

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -26,8 +26,22 @@ class App extends Component {
       })
       .catch(console.warn)
 
-    window.addEventListener('beforeunload', function(event) {
+    window.addEventListener('beforeunload', function() {
       sendToMainProcess('ui-unload')
+    })
+
+    window.addEventListener('online', () => {
+      this.props.dispatch({
+        type: 'connectivity-state-changed',
+        payload: { ok: true }
+      })
+    })
+
+    window.addEventListener('offline', () => {
+      this.props.dispatch({
+        type: 'connectivity-state-changed',
+        payload: { ok: false }
+      })
     })
   }
 
@@ -38,8 +52,7 @@ class App extends Component {
     })
   }
 
-  onPasswordAccepted = () =>
-    this.props.dispatch({ type: 'session-started' })
+  onPasswordAccepted = () => this.props.dispatch({ type: 'session-started' })
 
   render() {
     const { isSessionActive, hasEnoughData } = this.props

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -205,6 +205,7 @@ class Dashboard extends React.Component {
     mtnBalanceUSD: PropTypes.string.isRequired,
     ethBalanceWei: PropTypes.string.isRequired,
     ethBalanceUSD: PropTypes.string.isRequired,
+    isSendEnabled: PropTypes.bool.isRequired,
     transactions: PropTypes.array.isRequired,
     address: PropTypes.string.isRequired
   }
@@ -233,6 +234,7 @@ class Dashboard extends React.Component {
       mtnBalanceUSD,
       ethBalanceWei,
       ethBalanceUSD,
+      isSendEnabled,
       transactions
     } = this.props
 
@@ -269,7 +271,12 @@ class Dashboard extends React.Component {
           </Left>
 
           <Right>
-            <Btn block data-modal="send" onClick={this.onOpenModal}>
+            <Btn
+              data-modal="send"
+              disabled={!isSendEnabled}
+              onClick={this.onOpenModal}
+              block
+            >
               Send
             </Btn>
 
@@ -303,6 +310,7 @@ const mapStateToProps = state => ({
   mtnBalanceUSD: selectors.getMtnBalanceUSD(state),
   ethBalanceWei: selectors.getEthBalanceWei(state),
   ethBalanceUSD: selectors.getEthBalanceUSD(state),
+  isSendEnabled: selectors.isSendEnabled(state),
   transactions: selectors.getActiveWalletTransactions(state),
   address: selectors.getActiveWalletAddresses(state)[0]
 })

--- a/src/components/OfflineWarning.js
+++ b/src/components/OfflineWarning.js
@@ -1,0 +1,70 @@
+import * as selectors from '../selectors'
+import { connect } from 'react-redux'
+import { BaseBtn, CloseIcon } from './common'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import React from 'react'
+
+const Container = styled.div`
+  position: fixed;
+  top: 0;
+  z-index: 3;
+  right: 0;
+  left: 0;
+  padding: 0.4rem;
+  background: rgba(248, 123, 97, 1);
+  text-align: center;
+  font-size: 1.2rem;
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.2);
+`
+
+const DismissBtn = BaseBtn.extend`
+  position: relative;
+  top: 1px;
+  left: 6px;
+`
+
+class OfflineWarning extends React.Component {
+  static propTypes = {
+    isOnline: PropTypes.bool.isRequired
+  }
+
+  constructor(props) {
+    super(props)
+    this.state = {
+      isVisible: !props.isOnline
+    }
+  }
+
+  componentWillReceiveProps(newProps) {
+    if (newProps.isOnline) {
+      this.setState({ isVisible: false })
+    } else if (newProps.isOnline !== this.props.isOnline) {
+      this.setState({ isVisible: true })
+    }
+  }
+
+  onDismissClick = () => this.setState({ isVisible: false })
+
+  render() {
+    const { isVisible } = this.state
+
+    return (
+      isVisible && (
+        <Container>
+          Your wallet is not connected to the network. Check your internet
+          connection.{' '}
+          <DismissBtn onClick={this.onDismissClick}>
+            <CloseIcon size="1.2rem" />
+          </DismissBtn>
+        </Container>
+      )
+    )
+  }
+}
+
+const mapStateToProps = state => ({
+  isOnline: selectors.getIsOnline(state)
+})
+
+export default connect(mapStateToProps)(OfflineWarning)

--- a/src/components/Router.js
+++ b/src/components/Router.js
@@ -1,6 +1,7 @@
 import { HashRouter, Switch, Route, Redirect } from 'react-router-dom'
 import React, { Component } from 'react'
 import RecoverFromMnemonic from './RecoverFromMnemonic'
+import OfflineWarning from './OfflineWarning'
 import Dashboard from './Dashboard'
 import Converter from './Converter'
 import Settings from './Settings'
@@ -43,6 +44,7 @@ export default class Router extends Component {
               <Route component={Help} path="/help" />
             </Switch>
           </Main>
+          <OfflineWarning />
         </Container>
       </HashRouter>
     )

--- a/src/reducers/connectivity.js
+++ b/src/reducers/connectivity.js
@@ -1,0 +1,17 @@
+import { handleActions } from 'redux-actions'
+
+const initialState = {
+  isOnline: true
+}
+
+const reducer = handleActions(
+  {
+    'connectivity-state-changed': (state, action) => ({
+      ...state,
+      isOnline: Boolean(action.payload.ok)
+    })
+  },
+  initialState
+)
+
+export default reducer

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,4 +1,5 @@
 import { combineReducers } from 'redux'
+import connectivity from './connectivity'
 import blockchain from './blockchain'
 import converter from './converter'
 import wallets from './wallets'
@@ -7,6 +8,7 @@ import session from './session'
 import rates from './rates'
 
 export default combineReducers({
+  connectivity,
   blockchain,
   converter,
   wallets,

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -30,6 +30,13 @@ function getTxType(meta, tokenData, transaction, address) {
   return 'unknown'
 }
 
+export const getConnectivity = state => state.connectivity
+
+export const getIsOnline = createSelector(
+  getConnectivity,
+  connectivityStatus => connectivityStatus.isOnline
+)
+
 export const getIsLoggedIn = state => state.session.isLoggedIn
 
 export const isSessionActive = createSelector(getIsLoggedIn, pass => !!pass)
@@ -250,9 +257,21 @@ export const hasEnoughData = createSelector(
     blockHeight !== null
 )
 
+export const isSendEnabled = createSelector(
+  getActiveWalletEthBalance,
+  getActiveWalletMtnBalance,
+  getIsOnline,
+  (ethBalance, mtnBalance, isOnline) => {
+    const hasFunds = val => val && Web3.utils.toBN(val).gt(Web3.utils.toBN(0))
+    return isOnline && (hasFunds(ethBalance) || hasFunds(mtnBalance))
+  }
+)
+
 export const isAuctionEnabled = createSelector(
   getAuctionStatus,
-  auctionStatus =>
+  getIsOnline,
+  (auctionStatus, isOnline) =>
+    isOnline &&
     auctionStatus &&
     auctionStatus.tokenRemaining &&
     Web3.utils.toBN(auctionStatus.tokenRemaining).gt(Web3.utils.toBN(0))
@@ -260,12 +279,13 @@ export const isAuctionEnabled = createSelector(
 
 export const isConverterEnabled = createSelector(
   getCurrentAuction,
-  currentAuction => {
+  getIsOnline,
+  (currentAuction, isOnline) => {
     const isInDailyAuction = parseInt(currentAuction, 10) > 0
 
     // TODO remove this when Converter Contract is working fine
     const isConverterWorking = false
 
-    return isConverterWorking && isInDailyAuction
+    return isConverterWorking && isInDailyAuction && isOnline
   }
 )

--- a/src/subscriptions.js
+++ b/src/subscriptions.js
@@ -8,6 +8,7 @@ export const subscribeToMainProcessMessages = store => {
    */
   subscribeTo([
     'mtn-converter-status-updated',
+    'connectivity-state-changed',
     'auction-status-updated',
     'wallet-state-changed',
     'eth-price-updated',


### PR DESCRIPTION
  - Store connectivity status in Redux store to use in different components
  - Display a user-dismissable warning banner when the wallet connectivity is lost
  - Remove warning banner when wallet is online again
  - Disable "Send", "Buy" and "Convert" buttons when wallet is offline

Closes #72