### PR TITLE
Cleanup debian build

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     },
     "linux": {
       "artifactName": "${name}_v${version}.${ext}",
-      "category": "Finance",
+      "category": "Office;Finance",
       "target": [
         "deb"
       ],

--- a/ppa/README.md
+++ b/ppa/README.md
@@ -17,6 +17,7 @@ DEBFILE=metronome-desktop-wallet_v$VER.deb
 mkdir -p dist/app
 dpkg -x dist/$DEBFILE ./dist/app/
 rm -r dist/app/opt/Metronome\ Wallet/resources/app.asar.unpacked/node_modules/7zip-bin-linux/arm*
+perl -pi -e 's/opt/usr\/lib/' dist/app/usr/share/applications/metronome-desktop-wallet.desktop
 tar -czf ppa/$TARFILE -C dist/ app/
 rm -r dist/app/
 cd ppa/

--- a/ppa/app/debian/control
+++ b/ppa/app/debian/control
@@ -9,6 +9,6 @@ Build-Depends: debhelper (>= 9), libcairo2, libxcursor1, libxcomposite1, libpang
 Package: metronome-desktop-wallet
 Architecture: amd64
 Depends: ${shlibs:Depends}, ${misc:Depends}, libcairo2, libxcursor1, libxcomposite1, libpangocairo-1.0-0, libxdamage1, libxrandr2, libatk1.0-0, libx11-xcb1, libxi6, libxext6, libxss1, libgconf2-4, libnss3, libnspr4, libasound2, libcups2, libgtk2.0-0, libxtst6
-Description: Metronome Desktop Wallet
+Description: Cross Platform Desktop Wallet for Metronome
  metronome-desktop-wallet is an electron-based wallet for the
  Metronome Token.

--- a/ppa/app/debian/install
+++ b/ppa/app/debian/install
@@ -1,2 +1,0 @@
-usr/share/ usr/
-opt/ 

--- a/ppa/app/debian/rules
+++ b/ppa/app/debian/rules
@@ -5,5 +5,8 @@
 
 override_dh_makeshlibs override_dh_perl:
 
+override_dh_install:
+	dh_install usr/share/ usr/
+	dh_install "opt/Metronome\ Wallet/" usr/lib/
 override_dh_link:
-	dh_link opt/Metronome\ Wallet/metronome-desktop-wallet usr/bin/metronome-desktop-wallet
+	dh_link usr/lib/Metronome\ Wallet/metronome-desktop-wallet usr/bin/metronome-desktop-wallet


### PR DESCRIPTION
Move deb source build to /usr/lib since /opt is strongly discouraged
by Debian.

Fix category in desktop entry.

Fix description in control file.