### PR TITLE
ppa script

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "dev": "concurrently \"BROWSER=none npm start\" \"wait-on $npm_package_config_cra_dev_serv && ELECTRON_START_URL=$npm_package_config_cra_dev_serv electron .\"",
     "debug": "concurrently \"BROWSER=none npm start\" \"wait-on $npm_package_config_cra_dev_serv && ELECTRON_START_URL=$npm_package_config_cra_dev_serv electron . --inspect\"",
     "dist": "react-scripts build && build --em.main=build/electron.js",
+	"ppa": "TARFILE=\"$npm_package_name\"_$npm_package_version.orig.tar.gz; DEBFILE=\"$npm_package_name\"_v$npm_package_version.deb; mkdir -p dist/app; dpkg -x dist/$DEBFILE ./dist/app/ && rm -r dist/app/opt/Metronome\\ Wallet/resources/app.asar.unpacked/node_modules/7zip-bin-linux/arm* && perl -pi -e 's/opt/usr\\/lib/' dist/app/usr/share/applications/metronome-desktop-wallet.desktop && tar -czf ppa/$TARFILE -C dist/ app/ && rm -r dist/app && cd ppa && tar -xzf $TARFILE",
     "release": "react-scripts build && build --em.main=build/electron.js --publish always",
     "postinstall": "electron-builder install-app-deps"
   },

--- a/ppa/README.md
+++ b/ppa/README.md
@@ -1,43 +1,26 @@
 # Building for Launchpad PPA
 
-Launchpad pacakges need to be signed by someone who has signed the Ubuntu Code of Conduct so they cannot be done by an automated build system.
+Launchpad pacakges need to be signed by someone who has signed the Ubuntu Code of Conduct so they cannot be completely done by an automated build system.
 
 To post a `.deb` on Launchpad for Ubuntu a debian source package needs to be made and uploaded which is then built into a binary `.deb` by Launchpad.  Since this wallet is made with Electron this is complicated since the normal Electron build process download node packages (including electron) from the internet which is not possible for a source deb to do.  Since we are providing code, as a comprimise, we will generate a source deb that contains the mostly prebuilt files for amd64.
 
 For compatibility purposes it is best to do this on Ubuntu 16.04/Xenial (the oldest system we are distributing for).
 
-If this is a new version of the wallet you will need to update the changelog for the new version with `dch -ir xenail` before the first `debuild` run.
-
 ```
 yarn install
 yarn dist
+yarn ppa
 VER=0.6.0
-TARFILE=metronome-desktop-wallet_$VER.orig.tar.gz
-DEBFILE=metronome-desktop-wallet_v$VER.deb
-mkdir -p dist/app
-dpkg -x dist/$DEBFILE ./dist/app/
-rm -r dist/app/opt/Metronome\ Wallet/resources/app.asar.unpacked/node_modules/7zip-bin-linux/arm*
-perl -pi -e 's/opt/usr\/lib/' dist/app/usr/share/applications/metronome-desktop-wallet.desktop
-tar -czf ppa/$TARFILE -C dist/ app/
-rm -r dist/app/
-cd ppa/
-tar -xzf $TARFILE
-cd app
+cd ppa/app
+dch -i --distribution xenial
 debuild -us -uc
-debsign
+dch -i --distribution artful
+debuild -us -uc
+dch -i --distribution bionic
+debuild -us -uc
 cd ..
+debsign *.changes *.dsc
 dput ppa:metronome/metronome-desktop-wallet metronome-desktop-wallet_$VER-1xenial_source.changes
-cd app
-dch -ir artful
-debuild -us -uc
-debsign
-cd ..
 dput ppa:metronome/metronome-desktop-wallet metronome-desktop-wallet_$VER-1artful_source.changes
-cd app
-dch -ir bionic
-debuild -us -uc
-debsign
-cd ..
 dput ppa:metronome/metronome-desktop-wallet metronome-desktop-wallet_$VER-1bionic_source.changes
 ```
-


### PR DESCRIPTION
This moves most of the ppa building to an npm/yarn script.

This cannot be merged until after #165 goes in (I will rebase it after that) otherwise there will be conflicts for sure.