### PR TITLE
Validate password entropy only on password creation

### DIFF
--- a/src/components/Onboarding.js
+++ b/src/components/Onboarding.js
@@ -108,7 +108,7 @@ export default class Onboarding extends React.Component {
   // Perform validations and return an object of type { fieldId: [String] }
   validatePass = () => {
     const { password, passwordAgain } = this.state
-    const errors = validators.validatePassword(password)
+    const errors = validators.validatePasswordCreation(password)
 
     if (!errors.password && !passwordAgain) {
       errors.passwordAgain = 'Repeat the password'

--- a/src/validator.js
+++ b/src/validator.js
@@ -72,6 +72,14 @@ export function validateMnemonic(mnemonic, propName = 'mnemonic', errors = {}) {
 export function validatePassword(password, errors = {}) {
   if (!password) {
     errors.password = 'Password is required'
+  }
+
+  return errors
+}
+
+export function validatePasswordCreation(password, errors = {}) {
+  if (!password) {
+    errors.password = 'Password is required'
   } else if (stringEntropy(password) < 72) {
     errors.password = 'Password is not strong enough'
   }


### PR DESCRIPTION
This is needed to allow a user to access the wallet with a previously-defined password.

Related to #204 