### PR TITLE
Improve handling of invalid values in ETH/USD fields

### DIFF
--- a/src/components/AmountFields.js
+++ b/src/components/AmountFields.js
@@ -16,6 +16,8 @@ export default class AmountFields extends React.Component {
     }).isRequired
   }
 
+  static INVALID_PLACEHOLDER = 'Invalid amount'
+
   onMaxClick = () => {
     const ethAmount = Web3.utils.fromWei(this.props.availableETH)
     this.props.onChange({ target: { id: 'ethAmount', value: ethAmount } })
@@ -31,12 +33,18 @@ export default class AmountFields extends React.Component {
             MAX
           </FieldBtn>
           <TextInput
-            placeholder="0.00"
+            placeholder={
+              ethAmount === AmountFields.INVALID_PLACEHOLDER
+                ? AmountFields.INVALID_PLACEHOLDER
+                : '0.00'
+            }
             autoFocus={autoFocus}
             onChange={onChange}
             error={errors.ethAmount}
             label="Amount (ETH)"
-            value={ethAmount}
+            value={
+              ethAmount === AmountFields.INVALID_PLACEHOLDER ? '' : ethAmount
+            }
             id="ethAmount"
           />
         </Flex.Item>
@@ -45,11 +53,17 @@ export default class AmountFields extends React.Component {
         </Sp>
         <Flex.Item grow="1" basis="0">
           <TextInput
-            placeholder="0.00"
+            placeholder={
+              usdAmount === AmountFields.INVALID_PLACEHOLDER
+                ? AmountFields.INVALID_PLACEHOLDER
+                : '0.00'
+            }
             onChange={onChange}
             error={errors.usdAmount}
             label="Amount (USD)"
-            value={usdAmount}
+            value={
+              usdAmount === AmountFields.INVALID_PLACEHOLDER ? '' : usdAmount
+            }
             id="usdAmount"
           />
         </Flex.Item>

--- a/src/components/BuyMETDrawer.js
+++ b/src/components/BuyMETDrawer.js
@@ -66,9 +66,13 @@ class BuyMETDrawer extends React.Component {
     this.setState(state => ({
       ...state,
       usdAmount:
-        id === 'ethAmount' ? utils.toUSD(value, ETHprice) : state.usdAmount,
+        id === 'ethAmount'
+          ? utils.toUSD(value, ETHprice, AmountFields.INVALID_PLACEHOLDER)
+          : state.usdAmount,
       ethAmount:
-        id === 'usdAmount' ? utils.toETH(value, ETHprice) : state.ethAmount,
+        id === 'usdAmount'
+          ? utils.toETH(value, ETHprice, AmountFields.INVALID_PLACEHOLDER)
+          : state.ethAmount,
       errors: { ...state.errors, [id]: null },
       [id]: value
     }))

--- a/src/components/ConvertETHtoMETForm.js
+++ b/src/components/ConvertETHtoMETForm.js
@@ -55,8 +55,14 @@ class ConvertETHtoMETForm extends React.Component {
 
     this.setState(state => ({
       ...state,
-      usdAmount: id === 'ethAmount' ? toUSD(value, ETHprice) : state.usdAmount,
-      ethAmount: id === 'usdAmount' ? toETH(value, ETHprice) : state.ethAmount,
+      usdAmount:
+        id === 'ethAmount'
+          ? toUSD(value, ETHprice, AmountFields.INVALID_PLACEHOLDER)
+          : state.usdAmount,
+      ethAmount:
+        id === 'usdAmount'
+          ? toETH(value, ETHprice, AmountFields.INVALID_PLACEHOLDER)
+          : state.ethAmount,
       errors: { ...state.errors, [id]: null },
       [id]: value
     }))

--- a/src/components/SendETHForm.js
+++ b/src/components/SendETHForm.js
@@ -54,8 +54,14 @@ class SendETHForm extends React.Component {
 
     this.setState(state => ({
       ...state,
-      usdAmount: id === 'ethAmount' ? toUSD(value, ETHprice) : state.usdAmount,
-      ethAmount: id === 'usdAmount' ? toETH(value, ETHprice) : state.ethAmount,
+      usdAmount:
+        id === 'ethAmount'
+          ? toUSD(value, ETHprice, AmountFields.INVALID_PLACEHOLDER)
+          : state.usdAmount,
+      ethAmount:
+        id === 'usdAmount'
+          ? toETH(value, ETHprice, AmountFields.INVALID_PLACEHOLDER)
+          : state.ethAmount,
       errors: { ...state.errors, [id]: null },
       [id]: value
     }))

--- a/src/components/common/TextInput.js
+++ b/src/components/common/TextInput.js
@@ -69,31 +69,21 @@ export default class TextInput extends React.Component {
     id: PropTypes.string.isRequired
   }
 
-  state = { isPristine: true }
-
   InputControl = this.props.rows || this.props.cols
     ? Input.withComponent('textarea')
     : Input
 
-  componentWillReceiveProps(newProps) {
-    if (newProps.value !== this.props.value) {
-      this.setState({ isPristine: false })
-    }
-  }
-
   render() {
     const { label, value, type, id, error, ...other } = this.props
-    const { isPristine } = this.state
 
     const hasErrors = error && error.length > 0
 
     return (
       <div>
-        <Label isPristine={isPristine} hasErrors={hasErrors} htmlFor={id}>
+        <Label hasErrors={hasErrors} htmlFor={id}>
           {label}
         </Label>
         <this.InputControl
-          isPristine={isPristine}
           hasErrors={hasErrors}
           value={value || ''}
           type={type || 'text'}


### PR DESCRIPTION
Now the "Invalid amount" message is displayed as an input placeholder instead of an input value (which might be confusing).