### PR TITLE
Add more UI tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,9 +149,10 @@
     "eslint-plugin-node": "^5.2.1",
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-standard": "^3.0.1",
+    "expect": "^22.4.3",
     "prettier": "^1.10.2",
     "proxyquire": "^1.8.0",
-    "react-testing-library": "^1.6.0",
+    "react-testing-library": "^1.8.1",
     "wait-on": "^2.1.0"
   }
 }

--- a/src/components/BalanceBlock.js
+++ b/src/components/BalanceBlock.js
@@ -98,17 +98,21 @@ class BalanceBlock extends React.Component {
       <React.Fragment>
         <Balance>
           <CoinSymbol>MET</CoinSymbol>
-          <Value large>
+          <Value data-testid="met-balance" large>
             <DisplayValue maxSize="inherit" value={mtnBalanceWei} />
           </Value>
-          <USDValue hide>${mtnBalanceUSD} (USD)</USDValue>
+          <USDValue data-testid="met-balance-usd" hide>
+            ${mtnBalanceUSD} (USD)
+          </USDValue>
         </Balance>
         <Balance>
           <CoinSymbol>ETH</CoinSymbol>
-          <Value>
+          <Value data-testid="eth-balance">
             <DisplayValue maxSize="inherit" value={ethBalanceWei} />
           </Value>
-          <USDValue>${ethBalanceUSD} (USD)</USDValue>
+          <USDValue data-testid="eth-balance-usd">
+            ${ethBalanceUSD} (USD)
+          </USDValue>
         </Balance>
       </React.Fragment>
     )

--- a/src/components/ConvertDrawer.js
+++ b/src/components/ConvertDrawer.js
@@ -17,18 +17,19 @@ const Arrow = styled.span`
 export default class ConvertDrawer extends React.Component {
   static propTypes = {
     onRequestClose: PropTypes.func.isRequired,
+    defaultTab: PropTypes.string,
     isOpen: PropTypes.bool.isRequired
   }
 
-  static initialState = {
-    activeTab: 'ethToMet'
+  initialState = {
+    activeTab: this.props.defaultTab || 'ethToMet'
   }
 
-  state = ConvertDrawer.initialState
+  state = this.initialState
 
   componentWillReceiveProps(newProps) {
     if (newProps.isOpen && newProps.isOpen !== this.props.isOpen) {
-      this.setState(ConvertDrawer.initialState)
+      this.setState(this.initialState)
     }
   }
 

--- a/src/components/ConvertDrawer.js
+++ b/src/components/ConvertDrawer.js
@@ -64,7 +64,12 @@ export default class ConvertDrawer extends React.Component {
     )
 
     return (
-      <Drawer onRequestClose={onRequestClose} isOpen={isOpen} title="Converter">
+      <Drawer
+        onRequestClose={onRequestClose}
+        data-testid="convert-drawer"
+        isOpen={isOpen}
+        title="Converter"
+      >
         {activeTab === 'ethToMet' && <ConvertETHtoMETForm tabs={tabs} />}
         {activeTab === 'metToEth' && <ConvertMETtoETHForm tabs={tabs} />}
       </Drawer>

--- a/src/components/ConvertDrawer.js
+++ b/src/components/ConvertDrawer.js
@@ -17,7 +17,7 @@ const Arrow = styled.span`
 export default class ConvertDrawer extends React.Component {
   static propTypes = {
     onRequestClose: PropTypes.func.isRequired,
-    defaultTab: PropTypes.string,
+    defaultTab: PropTypes.oneOf(['ethToMet', 'metToEth']),
     isOpen: PropTypes.bool.isRequired
   }
 

--- a/src/components/ConvertETHtoMETForm.js
+++ b/src/components/ConvertETHtoMETForm.js
@@ -99,7 +99,7 @@ class ConvertETHtoMETForm extends React.Component {
   renderConfirmation = () => {
     const { ethAmount, usdAmount, estimate } = this.state
     return (
-      <ConfirmationContainer>
+      <ConfirmationContainer data-testid="confirmation">
         You will convert{' '}
         <DisplayValue value={Web3.utils.toWei(ethAmount)} post=" ETH" inline />{' '}
         (${usdAmount}) and get approximately{' '}
@@ -113,7 +113,12 @@ class ConvertETHtoMETForm extends React.Component {
       <Flex.Column grow="1">
         {this.props.tabs}
         <Sp py={4} px={3}>
-          <form onSubmit={goToReview} id="convertForm" noValidate>
+          <form
+            data-testid="ethToMet-form"
+            noValidate
+            onSubmit={goToReview}
+            id="convertForm"
+          >
             <AmountFields
               availableETH={this.props.availableETH}
               ethAmount={this.state.ethAmount}

--- a/src/components/ConvertMETtoETHForm.js
+++ b/src/components/ConvertMETtoETHForm.js
@@ -103,7 +103,7 @@ class ConvertMETtoETHForm extends React.Component {
   renderConfirmation = () => {
     const { metAmount, estimate } = this.state
     return (
-      <ConfirmationContainer>
+      <ConfirmationContainer data-testid="confirmation">
         You will convert{' '}
         <DisplayValue value={Web3.utils.toWei(metAmount)} post=" MET" inline />{' '}
         and get approximately{' '}
@@ -117,13 +117,24 @@ class ConvertMETtoETHForm extends React.Component {
       <Flex.Column grow="1">
         {this.props.tabs}
         <Sp py={4} px={3}>
-          <form onSubmit={goToReview} id="convertForm" noValidate>
+          <form
+            data-testid="metToEth-form"
+            noValidate
+            onSubmit={goToReview}
+            id="convertForm"
+          >
             <div>
-              <FieldBtn onClick={this.onMaxClick} tabIndex="-1" float>
+              <FieldBtn
+                data-testid="max-btn"
+                tabIndex="-1"
+                onClick={this.onMaxClick}
+                float
+              >
                 MAX
               </FieldBtn>
               <TextInput
                 placeholder="0.00"
+                data-testid="metAmount-field"
                 autoFocus
                 onChange={this.onInputChange}
                 error={this.state.errors.metAmount}

--- a/src/components/Converter.js
+++ b/src/components/Converter.js
@@ -148,7 +148,7 @@ class Converter extends React.Component {
       >
         {converterStatus ? (
           <Container>
-            <StatsContainer>
+            <StatsContainer data-testid="stats">
               <Sp p={2}>
                 <Flex.Row justify="space-between" align="baseline">
                   <Label>Current Price</Label>
@@ -207,6 +207,7 @@ class Converter extends React.Component {
                       : null
               }
               data-modal="convert"
+              data-testid="convert-btn"
               onClick={convertFeatureStatus === 'ok' ? this.onOpenModal : null}
             >
               Convert
@@ -219,7 +220,7 @@ class Converter extends React.Component {
           </Container>
         ) : (
           <Sp p={6}>
-            <LoadingContainer>
+            <LoadingContainer data-testid="waiting">
               <Text>Waiting for converter status...</Text>
               <Sp py={2}>
                 <LoadingBar />

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -115,6 +115,7 @@ class Dashboard extends React.Component {
           <Right>
             <Btn
               data-disabled={sendFeatureStatus !== 'ok' ? true : null}
+              data-testid="send-btn"
               data-rh={
                 sendFeatureStatus === 'offline'
                   ? "Can't send while offline"
@@ -129,7 +130,12 @@ class Dashboard extends React.Component {
               Send
             </Btn>
 
-            <ReceiveBtn block data-modal="receive" onClick={this.onOpenModal}>
+            <ReceiveBtn
+              data-testid="receive-btn"
+              data-modal="receive"
+              onClick={this.onOpenModal}
+              block
+            >
               Receive
             </ReceiveBtn>
           </Right>
@@ -138,7 +144,7 @@ class Dashboard extends React.Component {
         {hasTransactions ? (
           <TxList />
         ) : (
-          <NoTx>No transactions to show yet.</NoTx>
+          <NoTx data-testid="notx-msg">No transactions to show yet.</NoTx>
         )}
 
         <ReceiveDrawer

--- a/src/components/DashboardHeader.js
+++ b/src/components/DashboardHeader.js
@@ -96,7 +96,7 @@ class DashboardHeader extends React.Component {
         <AddressContainer>
           <Label>Address</Label>
           <Bg>
-            <Address>{address}</Address>
+            <Address data-testid="address">{address}</Address>
             <CopyBtn onClick={this.onCopyToClipboardClick}>Copy</CopyBtn>
           </Bg>
         </AddressContainer>

--- a/src/components/ReceiptModal.js
+++ b/src/components/ReceiptModal.js
@@ -137,7 +137,7 @@ class ReceiptModal extends React.Component {
         onRequestClose={onRequestClose}
         isOpen={isOpen}
       >
-        <Container>
+        <Container data-testid="receipt-modal">
           {tx.parsed.txType !== 'unknown' && (
             <Row first>
               <Label>Amount</Label>

--- a/src/components/ReceiveDrawer.js
+++ b/src/components/ReceiveDrawer.js
@@ -118,6 +118,7 @@ class Receive extends React.Component {
     return (
       <Drawer
         onRequestClose={onRequestClose}
+        data-testid="receive-drawer"
         isOpen={isOpen}
         title="Receive Transaction"
       >

--- a/src/components/ReceiveDrawer.js
+++ b/src/components/ReceiveDrawer.js
@@ -95,7 +95,7 @@ const QRmsg = styled.div`
   text-shadow: 0 1px 1px ${p => p.theme.colors.darkShade};
 `
 
-class Receive extends React.Component {
+class ReceiveDrawer extends React.Component {
   static propTypes = {
     onRequestClose: PropTypes.func.isRequired,
     address: PropTypes.string.isRequired,
@@ -126,11 +126,17 @@ class Receive extends React.Component {
           <Body>
             <Flex.Column align="center">
               <Title>Your address</Title>
-              <Address>{address}</Address>
-              <CopyBtn onClick={this.onCopyToClipboardClick}>
+              <Address data-testid="address">{address}</Address>
+              <CopyBtn
+                data-testid="copy-btn"
+                onClick={this.onCopyToClipboardClick}
+              >
                 <CopyIcon />
               </CopyBtn>
-              <BtnLabel isCopied={copyStatus !== 'init'}>
+              <BtnLabel
+                data-testid="btn-label"
+                isCopied={copyStatus !== 'init'}
+              >
                 {copyStatus === 'init' ? 'Copy' : 'Copied to clipboard!'}
               </BtnLabel>
             </Flex.Column>
@@ -151,4 +157,4 @@ const mapStateToProps = state => ({
   address: selectors.getActiveWalletAddresses(state)[0]
 })
 
-export default connect(mapStateToProps)(Receive)
+export default connect(mapStateToProps)(ReceiveDrawer)

--- a/src/components/RecoverFromMnemonic.js
+++ b/src/components/RecoverFromMnemonic.js
@@ -51,7 +51,7 @@ class RecoverFromMnemonic extends React.Component {
 
   renderConfirmation = () => {
     return (
-      <Confirmation>
+      <Confirmation data-testid="confirmation">
         <h3>Are you sure?</h3>
         <p>This operation will overwrite and restart the current wallet!</p>
       </Confirmation>
@@ -62,10 +62,11 @@ class RecoverFromMnemonic extends React.Component {
     const { mnemonic, errors } = this.state
 
     return (
-      <form onSubmit={goToReview}>
+      <form data-testid="recover-form" onSubmit={goToReview}>
         <p>Enter the 12 words to recover your wallet.</p>
         <p>This action will replace your current stored seed!</p>
         <TextInput
+          data-testid="mnemonic-field"
           autoFocus
           onChange={this.onInputChanged}
           label="Recovery phrase"

--- a/src/components/SendDrawer.js
+++ b/src/components/SendDrawer.js
@@ -16,11 +16,15 @@ class SendDrawer extends React.Component {
       'ok'
     ]).isRequired,
     onRequestClose: PropTypes.func.isRequired,
+    defaultTab: PropTypes.oneOf(['eth', 'met']),
     isOpen: PropTypes.bool.isRequired
   }
 
   initialState = {
-    activeTab: this.props.sendMetFeatureStatus !== 'ok' ? 'eth' : 'met'
+    activeTab:
+      this.props.sendMetFeatureStatus !== 'ok'
+        ? 'eth'
+        : this.props.defaultTab === 'eth' ? 'eth' : 'met'
   }
 
   state = this.initialState
@@ -51,7 +55,11 @@ class SendDrawer extends React.Component {
                 ? 'MET transactions are disabled during Initial Auction'
                 : sendMetFeatureStatus === 'transfer-disabled'
                   ? 'MET transactions not enabled yet'
-                  : null
+                  : sendMetFeatureStatus === 'no-funds'
+                    ? 'You need some MET to send'
+                    : sendMetFeatureStatus === 'offline'
+                      ? "Can't send while offline"
+                      : null
           },
           { id: 'eth', label: 'ETH' }
         ]}

--- a/src/components/SendDrawer.js
+++ b/src/components/SendDrawer.js
@@ -61,6 +61,7 @@ class SendDrawer extends React.Component {
     return (
       <Drawer
         onRequestClose={onRequestClose}
+        data-testid="send-drawer"
         isOpen={isOpen}
         title="Send Transaction"
       >

--- a/src/components/SendETHForm.js
+++ b/src/components/SendETHForm.js
@@ -100,7 +100,7 @@ class SendETHForm extends React.Component {
   renderConfirmation = () => {
     const { ethAmount, usdAmount, toAddress } = this.state
     return (
-      <ConfirmationContainer>
+      <ConfirmationContainer data-testid="confirmation">
         You will send{' '}
         <DisplayValue value={Web3.utils.toWei(ethAmount)} post=" ETH" inline />{' '}
         (${usdAmount}) to the address {toAddress}.
@@ -121,6 +121,7 @@ class SendETHForm extends React.Component {
           >
             <TextInput
               placeholder="e.g. 0x2345678998765434567"
+              data-testid="toAddress-field"
               autoFocus
               onChange={this.onInputChange}
               error={this.state.errors.toAddress}

--- a/src/components/SendETHForm.js
+++ b/src/components/SendETHForm.js
@@ -113,7 +113,12 @@ class SendETHForm extends React.Component {
       <Flex.Column grow="1">
         {this.props.tabs}
         <Sp py={4} px={3}>
-          <form noValidate onSubmit={goToReview} id="sendForm">
+          <form
+            data-testid="sendEth-form"
+            noValidate
+            onSubmit={goToReview}
+            id="sendForm"
+          >
             <TextInput
               placeholder="e.g. 0x2345678998765434567"
               autoFocus

--- a/src/components/SendMETForm.js
+++ b/src/components/SendMETForm.js
@@ -118,7 +118,12 @@ class SendMETForm extends React.Component {
       <Flex.Column grow="1">
         {this.props.tabs}
         <Sp py={4} px={3}>
-          <form onSubmit={goToReview} id="sendForm" noValidate>
+          <form
+            data-testid="sendMet-form"
+            noValidate
+            onSubmit={goToReview}
+            id="sendForm"
+          >
             <TextInput
               placeholder="e.g. 0x2345678998765434567"
               autoFocus

--- a/src/components/SendMETForm.js
+++ b/src/components/SendMETForm.js
@@ -93,7 +93,7 @@ class SendMETForm extends React.Component {
   renderConfirmation = () => {
     const { metAmount, toAddress } = this.state
     return (
-      <ConfirmationContainer>
+      <ConfirmationContainer data-testid="confirmation">
         You will send{' '}
         <DisplayValue value={Web3.utils.toWei(metAmount)} post=" MET" inline />{' '}
         to the address {toAddress}.
@@ -126,6 +126,7 @@ class SendMETForm extends React.Component {
           >
             <TextInput
               placeholder="e.g. 0x2345678998765434567"
+              data-testid="toAddress-field"
               autoFocus
               onChange={this.onInputChange}
               error={this.state.errors.toAddress}
@@ -134,11 +135,17 @@ class SendMETForm extends React.Component {
               id="toAddress"
             />
             <Sp mt={3}>
-              <FieldBtn onClick={this.onMaxClick} tabIndex="-1" float>
+              <FieldBtn
+                data-testid="max-btn"
+                tabIndex="-1"
+                onClick={this.onMaxClick}
+                float
+              >
                 MAX
               </FieldBtn>
               <TextInput
                 placeholder="0.00"
+                data-testid="metAmount-field"
                 onChange={this.onInputChange}
                 error={this.state.errors.metAmount}
                 label="Amount (MET)"

--- a/src/components/TxList.js
+++ b/src/components/TxList.js
@@ -105,7 +105,14 @@ class TxList extends React.Component {
 
   componentDidMount() {
     // We need to grab the scrolling div (in <Router/>) to sync with react-virtualized scroll
-    this.scrollElement = document.querySelector('[data-scrollelement]')
+    const element = document.querySelector('[data-scrollelement]')
+    if (!element && process.env.NODE_ENV !== 'test') {
+      throw new Error(
+        "react-virtualized in transactions list requires the scrolling parent to have a 'data-scrollelement' attribute."
+      )
+    }
+    // For tests, where this component is rendered in isolation, we default to window
+    this.scrollElement = element || window
     this.setState({ isReady: true })
   }
 
@@ -121,6 +128,7 @@ class TxList extends React.Component {
   rowRenderer = items => ({ key, style, index }) => (
     <div style={style} key={`${key}-${items[index].transaction.hash}`}>
       <TxRow
+        data-testid="tx-row"
         data-hash={items[index].transaction.hash}
         onClick={this.onTxClicked}
         {...items[index]}
@@ -132,7 +140,7 @@ class TxList extends React.Component {
     const { items } = this.props
     if (!this.state.isReady) return null
     return (
-      <Container>
+      <Container data-testid="tx-list">
         <ItemFilter extractValue={tx => tx.parsed.txType} items={items}>
           {({ filteredItems, onFilterChange, activeFilter }) => (
             <React.Fragment>
@@ -192,8 +200,8 @@ class TxList extends React.Component {
                             rowHeight={65}
                             rowCount={filteredItems.length}
                             onScroll={onChildScroll}
-                            height={height}
-                            width={width}
+                            height={height || 500} // defaults for tests
+                            width={width || 500} // defaults for tests
                           />
                         )}
                       </AutoSizer>

--- a/src/components/TxRow.js
+++ b/src/components/TxRow.js
@@ -71,7 +71,7 @@ const Amount = styled.div`
   text-align: right;
   opacity: ${({ isPending }) => (isPending ? '0.5' : '1')};
   color: ${p =>
-    p.isPending || p.isCancelApproval
+    p.isPending
       ? p.theme.colors.copy
       : p.isFailed ? p.theme.colors.danger : p.theme.colors.primary};
   display: flex;

--- a/src/components/__tests__/AmountFields.test.js
+++ b/src/components/__tests__/AmountFields.test.js
@@ -1,0 +1,115 @@
+import { Simulate } from 'react-testing-library'
+import * as testUtils from '../../testUtils'
+import AmountFields from '../AmountFields'
+import React from 'react'
+
+const element = (
+  <AmountFields availableETH="100" onChange={jest.fn()} errors={{}} />
+)
+
+describe('<AmountFields/>', () => {
+  it('should match its snapshot', () => {
+    const { container } = testUtils.reduxRender(element)
+    expect(container).toMatchSnapshot()
+  })
+})
+
+export function runEditTests(element, initialState, rate) {
+  it('updates the USD field when ETH field changes', () => {
+    const { getByTestId } = testUtils.reduxRender(element, initialState)
+    const ethField = getByTestId('ethAmount-field')
+    const usdField = getByTestId('usdAmount-field')
+    expect(ethField.value).toBe('')
+    expect(usdField.value).toBe('')
+    ethField.value = '1'
+    Simulate.change(ethField)
+    expect(usdField.value).toBe(rate.toString())
+  })
+
+  it('updates the ETH field when USD field changes', () => {
+    const { getByTestId } = testUtils.reduxRender(element, initialState)
+    const ethField = getByTestId('ethAmount-field')
+    const usdField = getByTestId('usdAmount-field')
+    usdField.value = '500'
+    Simulate.change(usdField)
+    expect(ethField.value).toBe((500 / rate).toString())
+  })
+
+  it('updates ETH and USD fields when MAX button is clicked', () => {
+    const { getByTestId } = testUtils.reduxRender(element, initialState)
+    const ethField = getByTestId('ethAmount-field')
+    const usdField = getByTestId('usdAmount-field')
+    Simulate.click(getByTestId('max-btn'))
+    expect(ethField.value).toBe('5000')
+    expect(usdField.value).toBe((5000 * rate).toString())
+  })
+
+  it('displays a "Invalid amount" placeholder in USD field when ETH value is invalid', () => {
+    const { getByTestId } = testUtils.reduxRender(element, initialState)
+    const ethField = getByTestId('ethAmount-field')
+    const usdField = getByTestId('usdAmount-field')
+    expect(usdField.placeholder).toBe('0.00')
+    ethField.value = 'foo'
+    Simulate.change(ethField)
+    expect(usdField.value).toBe('')
+    expect(usdField.placeholder).toBe('Invalid amount')
+  })
+
+  it('displays a "Invalid amount" placeholder in ETH field when USD value is invalid', () => {
+    const { getByTestId } = testUtils.reduxRender(element, initialState)
+    const ethField = getByTestId('ethAmount-field')
+    const usdField = getByTestId('usdAmount-field')
+    expect(ethField.placeholder).toBe('0.00')
+    usdField.value = 'foo'
+    Simulate.change(usdField)
+    expect(ethField.value).toBe('')
+    expect(ethField.placeholder).toBe('Invalid amount')
+  })
+}
+
+export function runValidateTests(
+  element,
+  initialState,
+  formTestId,
+  fieldTestId = 'ethAmount-field'
+) {
+  it('displays an error if AMOUNT is not provided', () => {
+    const { getByTestId } = testUtils.reduxRender(element, initialState)
+    testUtils.testValidation(getByTestId, formTestId, {
+      formData: { [fieldTestId]: '' },
+      errors: { [fieldTestId]: 'Amount is required' }
+    })
+  })
+
+  it('displays an error if AMOUNT is negative', () => {
+    const { getByTestId } = testUtils.reduxRender(element, initialState)
+    testUtils.testValidation(getByTestId, formTestId, {
+      formData: { [fieldTestId]: '-1' },
+      errors: { [fieldTestId]: 'Amount must be greater than 0' }
+    })
+  })
+
+  it('displays an error if AMOUNT is an invalid value', () => {
+    const { getByTestId } = testUtils.reduxRender(element, initialState)
+    testUtils.testValidation(getByTestId, formTestId, {
+      formData: { [fieldTestId]: 'foo' },
+      errors: { [fieldTestId]: 'Invalid amount' }
+    })
+  })
+
+  it('displays an error if AMOUNT is more than what we have', () => {
+    const { getByTestId } = testUtils.reduxRender(element, initialState)
+    testUtils.testValidation(getByTestId, formTestId, {
+      formData: { [fieldTestId]: '10000' },
+      errors: { [fieldTestId]: 'Insufficient funds' }
+    })
+  })
+
+  it('displays an error if AMOUNT is not weiable', () => {
+    const { getByTestId } = testUtils.reduxRender(element, initialState)
+    testUtils.testValidation(getByTestId, formTestId, {
+      formData: { [fieldTestId]: '0.0000000000000000000000000000001' },
+      errors: { [fieldTestId]: 'Invalid amount' }
+    })
+  })
+}

--- a/src/components/__tests__/App.test.js
+++ b/src/components/__tests__/App.test.js
@@ -4,10 +4,14 @@ import config from '../../config'
 import React from 'react'
 import App from '../App'
 
+const getElement = (response = { onboardingComplete: true }) => (
+  <App onMount={() => Promise.resolve(response)} />
+)
+
 describe('<App/>', () => {
   it('displays a login form if user is already on board', async () => {
     const { queryByTestId } = reduxRender(
-      <App onMount={() => Promise.resolve({ onboardingComplete: true })} />
+      getElement({ onboardingComplete: true })
     )
     expect(queryByTestId('login-form')).toBeNull()
     await flushPromises()
@@ -16,7 +20,7 @@ describe('<App/>', () => {
 
   it('displays onboarding wizard if user is NOT on board', async () => {
     const { queryByTestId } = reduxRender(
-      <App onMount={() => Promise.resolve({ onboardingComplete: false })} />
+      getElement({ onboardingComplete: false })
     )
     expect(queryByTestId('onboarding-container')).toBeNull()
     await flushPromises()
@@ -24,9 +28,7 @@ describe('<App/>', () => {
   })
 
   it('displays a loading screen while waiting for wallet data', async () => {
-    const { queryByTestId, store } = reduxRender(
-      <App onMount={() => Promise.resolve({ onboardingComplete: true })} />
-    )
+    const { queryByTestId, store } = reduxRender(getElement())
     await flushPromises()
     expect(queryByTestId('loading-scene')).toBeNull()
     store.dispatch({ type: 'session-started' })
@@ -34,9 +36,7 @@ describe('<App/>', () => {
   })
 
   it('displays router after enough data was received', async () => {
-    const { queryByTestId, store } = reduxRender(
-      <App onMount={() => Promise.resolve({ onboardingComplete: true })} />
-    )
+    const { queryByTestId, store } = reduxRender(getElement())
     await flushPromises()
 
     // In order to display the inner screens of the wallet the Main Process

--- a/src/components/__tests__/Auction.test.js
+++ b/src/components/__tests__/Auction.test.js
@@ -1,4 +1,5 @@
 import * as testUtils from '../../testUtils'
+import { Simulate } from 'react-testing-library'
 import Auction from '../Auction'
 import config from '../../config'
 import React from 'react'
@@ -69,22 +70,28 @@ describe('<Auction/>', () => {
 
     describe('if there are tokens available', () => {
       it('opens Buy drawer when Buy button is clicked', () => {
-        const { getByTestId } = testUtils.reduxRender(
+        const { queryByTestId, getByTestId } = testUtils.reduxRender(
           <Auction />,
           getInitialState(inInitialAuction({ tokenRemaining: '100' }))
         )
-        testUtils.testModalIsCalled(getByTestId, 'buy-btn', 'buy-drawer')
+        const btn = testUtils.withDataset(getByTestId('buy-btn'), 'modal')
+        expect(queryByTestId('buy-drawer')).toBeNull()
+        Simulate.click(btn)
+        expect(queryByTestId('buy-drawer')).not.toBeNull()
       })
     })
 
     describe('if auction is depleted', () => {
       it('Buy button is disabled', () => {
-        const { getByTestId, store } = testUtils.reduxRender(
+        const { queryByTestId, getByTestId, store } = testUtils.reduxRender(
           <Auction />,
           getInitialState(inInitialAuction({ tokenRemaining: '100' }))
         )
         store.dispatch(auctionStatusUpdated({ tokenRemaining: '0' }))
-        testUtils.testModalIsCalled(getByTestId, 'buy-btn', 'buy-drawer', false)
+        const btn = testUtils.withDataset(getByTestId('buy-btn'), 'modal')
+        expect(queryByTestId('buy-drawer')).toBeNull()
+        Simulate.click(btn)
+        expect(queryByTestId('buy-drawer')).toBeNull()
       })
 
       it('Buy button shows a tooltip when hovered', () => {
@@ -102,12 +109,15 @@ describe('<Auction/>', () => {
 
     describe('if connectivity is lost', () => {
       it('Buy button is disabled', () => {
-        const { getByTestId, store } = testUtils.reduxRender(
+        const { queryByTestId, getByTestId, store } = testUtils.reduxRender(
           <Auction />,
           getInitialState(inInitialAuction())
         )
         store.dispatch(goOffline())
-        testUtils.testModalIsCalled(getByTestId, 'buy-btn', 'buy-drawer', false)
+        const btn = testUtils.withDataset(getByTestId('buy-btn'), 'modal')
+        expect(queryByTestId('buy-drawer')).toBeNull()
+        Simulate.click(btn)
+        expect(queryByTestId('buy-drawer')).toBeNull()
       })
 
       it('Buy button shows a tooltip when hovered', () => {
@@ -180,22 +190,28 @@ describe('<Auction/>', () => {
 
     describe('if there are tokens available', () => {
       it('opens Buy drawer when Buy button is clicked', () => {
-        const { getByTestId } = testUtils.reduxRender(
+        const { queryByTestId, getByTestId } = testUtils.reduxRender(
           <Auction />,
           getInitialState(inDailyAuction({ tokenRemaining: '100' }))
         )
-        testUtils.testModalIsCalled(getByTestId, 'buy-btn', 'buy-drawer')
+        const btn = testUtils.withDataset(getByTestId('buy-btn'), 'modal')
+        expect(queryByTestId('buy-drawer')).toBeNull()
+        Simulate.click(btn)
+        expect(queryByTestId('buy-drawer')).not.toBeNull()
       })
     })
 
     describe('if auction is depleted', () => {
       it('Buy button is disabled', () => {
-        const { getByTestId, store } = testUtils.reduxRender(
+        const { queryByTestId, getByTestId, store } = testUtils.reduxRender(
           <Auction />,
           getInitialState(inDailyAuction({ tokenRemaining: '100' }))
         )
         store.dispatch(auctionStatusUpdated({ tokenRemaining: '0' }))
-        testUtils.testModalIsCalled(getByTestId, 'buy-btn', 'buy-drawer', false)
+        const btn = testUtils.withDataset(getByTestId('buy-btn'), 'modal')
+        expect(queryByTestId('buy-drawer')).toBeNull()
+        Simulate.click(btn)
+        expect(queryByTestId('buy-drawer')).toBeNull()
       })
 
       it('Buy button shows a tooltip when hovered', () => {
@@ -213,12 +229,15 @@ describe('<Auction/>', () => {
 
     describe('if connectivity is lost', () => {
       it('Buy button is disabled', () => {
-        const { getByTestId, store } = testUtils.reduxRender(
+        const { queryByTestId, getByTestId, store } = testUtils.reduxRender(
           <Auction />,
           getInitialState(inDailyAuction())
         )
         store.dispatch(goOffline())
-        testUtils.testModalIsCalled(getByTestId, 'buy-btn', 'buy-drawer', false)
+        const btn = testUtils.withDataset(getByTestId('buy-btn'), 'modal')
+        expect(queryByTestId('buy-drawer')).toBeNull()
+        Simulate.click(btn)
+        expect(queryByTestId('buy-drawer')).toBeNull()
       })
 
       it('Buy button shows a tooltip when hovered', () => {

--- a/src/components/__tests__/ConvertDrawer.test.js
+++ b/src/components/__tests__/ConvertDrawer.test.js
@@ -1,0 +1,71 @@
+import * as testUtils from '../../testUtils'
+import ConvertDrawer from '../ConvertDrawer'
+import { Simulate } from 'react-testing-library'
+import config from '../../config'
+import React from 'react'
+
+const closeHandler = jest.fn()
+
+const getElement = defaultTab => (
+  <ConvertDrawer onRequestClose={closeHandler} defaultTab={defaultTab} isOpen />
+)
+
+describe('<ConvertDrawer/>', () => {
+  it('displays MET TO ETH form when clicking the tab', () => {
+    const { queryByTestId, getByTestId } = testUtils.reduxRender(
+      getElement(),
+      getInitialState()
+    )
+    expect(queryByTestId('metToEth-form')).toBeNull()
+    Simulate.click(testUtils.withDataset(getByTestId('metToEth-tab'), 'tab'))
+    expect(queryByTestId('metToEth-form')).not.toBeNull()
+  })
+
+  it('displays ETH TO MET form when clicking the tab', () => {
+    const { queryByTestId, getByTestId } = testUtils.reduxRender(
+      getElement('metToEth'),
+      getInitialState()
+    )
+    expect(queryByTestId('ethToMet-form')).toBeNull()
+    Simulate.click(testUtils.withDataset(getByTestId('ethToMet-tab'), 'tab'))
+    expect(queryByTestId('ethToMet-form')).not.toBeNull()
+  })
+})
+
+function getInitialState() {
+  return {
+    connectivity: { isOnline: true },
+    blockchain: { height: 1 },
+    metronome: { transferAllowed: true },
+    converter: {
+      status: {
+        currentPrice: '10'
+      }
+    },
+    auction: {
+      status: {
+        nextAuctionStartTime: testUtils.inOneHour(),
+        tokenRemaining: '100',
+        currentAuction: '5',
+        currentPrice: '10',
+        genesisTime: testUtils.twoWeeksAgo()
+      }
+    },
+    session: { isLoggedIn: true },
+    rates: { ETH: { token: 'ETH', price: 250 } },
+    wallets: {
+      active: 'foo',
+      allIds: ['foo'],
+      byId: {
+        foo: {
+          addresses: {
+            '0xf00': {
+              token: { [config.MTN_TOKEN_ADDR]: { balance: '0' } },
+              balance: '5000000000000000000000'
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/components/__tests__/ConvertETHtoMETForm.test.js
+++ b/src/components/__tests__/ConvertETHtoMETForm.test.js
@@ -1,25 +1,16 @@
+import ConvertETHtoMETForm from '../ConvertETHtoMETForm'
 import * as amountFields from './AmountFields.test.js'
 import * as gasEditor from './GasEditor.test.js'
 import * as testUtils from '../../testUtils'
 import { Simulate } from 'react-testing-library'
-import BuyMETDrawer from '../BuyMETDrawer'
 import config from '../../config'
 import React from 'react'
 
-const closeHandler = jest.fn()
-
-const element = (
-  <BuyMETDrawer
-    tokenRemaining="100"
-    onRequestClose={closeHandler}
-    currentPrice="10"
-    isOpen
-  />
-)
+const element = <ConvertETHtoMETForm />
 
 const ETHprice = 250
 
-describe('<BuyMETDrawer/>', () => {
+describe('<ConvertETHtoMETForm/>', () => {
   it('should match its snapshot', () => {
     const { container } = testUtils.reduxRender(element, getInitialState())
     expect(container).toMatchSnapshot()
@@ -30,9 +21,9 @@ describe('<BuyMETDrawer/>', () => {
   })
 
   describe('When submitting the form', () => {
-    amountFields.runValidateTests(element, getInitialState(), 'buy-form')
+    amountFields.runValidateTests(element, getInitialState(), 'ethToMet-form')
 
-    gasEditor.runValidateTests(element, getInitialState(), 'buy-form')
+    gasEditor.runValidateTests(element, getInitialState(), 'ethToMet-form')
 
     it('displays the confirmation view if there are no errors', () => {
       const { queryByTestId, getByTestId } = testUtils.reduxRender(
@@ -43,7 +34,7 @@ describe('<BuyMETDrawer/>', () => {
       const amountField = getByTestId('ethAmount-field')
       amountField.value = '1'
       Simulate.change(amountField)
-      Simulate.submit(getByTestId('buy-form'))
+      Simulate.submit(getByTestId('ethToMet-form'))
       expect(queryByTestId('confirmation')).not.toBeNull()
     })
   })
@@ -54,16 +45,12 @@ function getInitialState() {
     connectivity: { isOnline: true },
     blockchain: { height: 1 },
     metronome: { transferAllowed: true },
-    converter: { status: null },
-    auction: {
+    converter: {
       status: {
-        nextAuctionStartTime: testUtils.inOneHour(),
-        tokenRemaining: '100',
-        currentAuction: '5',
-        currentPrice: '10',
-        genesisTime: testUtils.twoWeeksAgo()
+        currentPrice: '10'
       }
     },
+    auction: { status: null },
     session: { isLoggedIn: true },
     rates: { ETH: { token: 'ETH', price: ETHprice } },
     wallets: {

--- a/src/components/__tests__/ConvertMETtoETHForm.test.js
+++ b/src/components/__tests__/ConvertMETtoETHForm.test.js
@@ -1,38 +1,39 @@
+import ConvertMETtoETHForm from '../ConvertMETtoETHForm'
 import * as amountFields from './AmountFields.test.js'
 import * as gasEditor from './GasEditor.test.js'
 import * as testUtils from '../../testUtils'
 import { Simulate } from 'react-testing-library'
-import BuyMETDrawer from '../BuyMETDrawer'
 import config from '../../config'
 import React from 'react'
 
-const closeHandler = jest.fn()
-
-const element = (
-  <BuyMETDrawer
-    tokenRemaining="100"
-    onRequestClose={closeHandler}
-    currentPrice="10"
-    isOpen
-  />
-)
+const element = <ConvertMETtoETHForm />
 
 const ETHprice = 250
 
-describe('<BuyMETDrawer/>', () => {
+describe('<ConvertMETtoETHForm/>', () => {
   it('should match its snapshot', () => {
     const { container } = testUtils.reduxRender(element, getInitialState())
     expect(container).toMatchSnapshot()
   })
 
-  describe('When editing the amount fields', () => {
-    amountFields.runEditTests(element, getInitialState(), ETHprice)
+  describe('When editing the amount field', () => {
+    it('updates MET field when MAX button is clicked', () => {
+      const { getByTestId } = testUtils.reduxRender(element, getInitialState())
+      const metField = getByTestId('metAmount-field')
+      Simulate.click(getByTestId('max-btn'))
+      expect(metField.value).toBe('5000')
+    })
   })
 
   describe('When submitting the form', () => {
-    amountFields.runValidateTests(element, getInitialState(), 'buy-form')
+    amountFields.runValidateTests(
+      element,
+      getInitialState(),
+      'metToEth-form',
+      'metAmount-field'
+    )
 
-    gasEditor.runValidateTests(element, getInitialState(), 'buy-form')
+    gasEditor.runValidateTests(element, getInitialState(), 'metToEth-form')
 
     it('displays the confirmation view if there are no errors', () => {
       const { queryByTestId, getByTestId } = testUtils.reduxRender(
@@ -40,10 +41,10 @@ describe('<BuyMETDrawer/>', () => {
         getInitialState()
       )
       expect(queryByTestId('confirmation')).toBeNull()
-      const amountField = getByTestId('ethAmount-field')
+      const amountField = getByTestId('metAmount-field')
       amountField.value = '1'
       Simulate.change(amountField)
-      Simulate.submit(getByTestId('buy-form'))
+      Simulate.submit(getByTestId('metToEth-form'))
       expect(queryByTestId('confirmation')).not.toBeNull()
     })
   })
@@ -54,16 +55,12 @@ function getInitialState() {
     connectivity: { isOnline: true },
     blockchain: { height: 1 },
     metronome: { transferAllowed: true },
-    converter: { status: null },
-    auction: {
+    converter: {
       status: {
-        nextAuctionStartTime: testUtils.inOneHour(),
-        tokenRemaining: '100',
-        currentAuction: '5',
-        currentPrice: '10',
-        genesisTime: testUtils.twoWeeksAgo()
+        currentPrice: '10'
       }
     },
+    auction: { status: null },
     session: { isLoggedIn: true },
     rates: { ETH: { token: 'ETH', price: ETHprice } },
     wallets: {
@@ -73,7 +70,9 @@ function getInitialState() {
         foo: {
           addresses: {
             '0xf00': {
-              token: { [config.MTN_TOKEN_ADDR]: { balance: '0' } },
+              token: {
+                [config.MTN_TOKEN_ADDR]: { balance: '5000000000000000000000' }
+              },
               balance: '5000000000000000000000'
             }
           }

--- a/src/components/__tests__/Converter.test.js
+++ b/src/components/__tests__/Converter.test.js
@@ -1,0 +1,193 @@
+import * as testUtils from '../../testUtils'
+import { Simulate } from 'react-testing-library'
+import Converter from '../Converter'
+import config from '../../config'
+import React from 'react'
+
+describe('<Converter/>', () => {
+  it('displays a "waiting..." message until the first converter status is received', () => {
+    const { queryByTestId, store } = testUtils.reduxRender(<Converter />)
+    expect(queryByTestId('waiting')).not.toBeNull()
+    store.dispatch(converterStatusUpdated(dummyStatus()))
+    expect(queryByTestId('waiting')).toBeNull()
+  })
+
+  describe('If MET conversions are NOT ALLOWED yet', () => {
+    it('displays stats', () => {
+      const { queryByTestId } = testUtils.reduxRender(
+        <Converter />,
+        getInitialState(dummyStatus(), inInitialAuction(), false)
+      )
+      expect(queryByTestId('stats')).not.toBeNull()
+    })
+
+    it('Convert button is disabled', () => {
+      const { getByTestId, queryByTestId } = testUtils.reduxRender(
+        <Converter />,
+        getInitialState(dummyStatus(), inDailyAuction(), false)
+      )
+      const btn = testUtils.withDataset(getByTestId('convert-btn'), 'modal')
+      expect(queryByTestId('convert-drawer')).toBeNull()
+      Simulate.click(btn)
+      expect(queryByTestId('convert-drawer')).toBeNull()
+    })
+
+    it('Convert button shows a tooltip when hovered', () => {
+      const { getByTestId, store } = testUtils.reduxRender(
+        <Converter />,
+        getInitialState(dummyStatus(), inDailyAuction())
+      )
+      expect(getByTestId('convert-btn').getAttribute('data-rh')).toBeNull()
+      store.dispatch(transferAllowed(false))
+      expect(getByTestId('convert-btn').getAttribute('data-rh')).toBe(
+        'MET conversions not enabled yet'
+      )
+    })
+  })
+
+  describe('If MET conversions ARE ALLOWED', () => {
+    it('opens Convert drawer when Convert button is clicked', () => {
+      const { queryByTestId, getByTestId } = testUtils.reduxRender(
+        <Converter />,
+        getInitialState(dummyStatus(), inDailyAuction())
+      )
+      const btn = testUtils.withDataset(getByTestId('convert-btn'), 'modal')
+      expect(queryByTestId('convert-drawer')).toBeNull()
+      Simulate.click(btn)
+      expect(queryByTestId('convert-drawer')).not.toBeNull()
+    })
+
+    describe('if we are on the INITIAL AUCTION', () => {
+      it('displays stats', () => {
+        const { queryByTestId } = testUtils.reduxRender(
+          <Converter />,
+          getInitialState(dummyStatus(), inInitialAuction())
+        )
+        expect(queryByTestId('stats')).not.toBeNull()
+      })
+
+      it('Convert button is disabled', () => {
+        const { getByTestId, queryByTestId } = testUtils.reduxRender(
+          <Converter />,
+          getInitialState(dummyStatus(), inInitialAuction())
+        )
+        const btn = testUtils.withDataset(getByTestId('convert-btn'), 'modal')
+        expect(queryByTestId('convert-drawer')).toBeNull()
+        Simulate.click(btn)
+        expect(queryByTestId('convert-drawer')).toBeNull()
+      })
+
+      it('Convert button shows a tooltip when hovered', () => {
+        const { getByTestId } = testUtils.reduxRender(
+          <Converter />,
+          getInitialState(dummyStatus(), inInitialAuction())
+        )
+        expect(getByTestId('convert-btn').getAttribute('data-rh')).toBe(
+          'Conversions are disabled during Initial Auction'
+        )
+      })
+    })
+
+    describe('if connectivity is lost', () => {
+      it('Convert button is disabled', () => {
+        const { queryByTestId, getByTestId, store } = testUtils.reduxRender(
+          <Converter />,
+          getInitialState(dummyStatus(), inDailyAuction())
+        )
+        store.dispatch(goOffline())
+        const btn = testUtils.withDataset(getByTestId('convert-btn'), 'modal')
+        expect(queryByTestId('convert-drawer')).toBeNull()
+        Simulate.click(btn)
+        expect(queryByTestId('convert-drawer')).toBeNull()
+      })
+
+      it('Convert button shows a tooltip when hovered', () => {
+        const { getByTestId, store } = testUtils.reduxRender(
+          <Converter />,
+          getInitialState(dummyStatus(), inDailyAuction())
+        )
+        expect(getByTestId('convert-btn').getAttribute('data-rh')).toBeNull()
+        store.dispatch(goOffline())
+        expect(getByTestId('convert-btn').getAttribute('data-rh')).toBe(
+          "Can't convert while offline"
+        )
+      })
+    })
+  })
+})
+
+function transferAllowed(value) {
+  return {
+    type: 'metronome-token-status-updated',
+    payload: { transferAllowed: value }
+  }
+}
+
+function converterStatusUpdated(payload = {}) {
+  return {
+    type: 'mtn-converter-status-updated',
+    payload
+  }
+}
+
+function goOffline() {
+  return {
+    type: 'connectivity-state-changed',
+    payload: { ok: false }
+  }
+}
+
+const dummyStatus = (overrides = {}) => ({
+  availableEth: '100',
+  availableMtn: '100',
+  currentPrice: '10',
+  ...overrides
+})
+
+const inInitialAuction = (overrides = {}) => ({
+  nextAuctionStartTime: testUtils.inOneWeek(),
+  tokenRemaining: '1',
+  currentAuction: '0',
+  currentPrice: '33000000000',
+  genesisTime: testUtils.oneHourAgo(),
+  ...overrides
+})
+
+const inDailyAuction = (overrides = {}) => ({
+  nextAuctionStartTime: testUtils.inOneHour(),
+  tokenRemaining: '1',
+  currentAuction: '10',
+  currentPrice: '33000000000',
+  genesisTime: testUtils.twoWeeksAgo(),
+  ...overrides
+})
+
+function getInitialState(
+  converterStatus = null,
+  auctionStatus = null,
+  transferAllowed = true
+) {
+  return {
+    connectivity: { isOnline: true },
+    blockchain: { height: 1 },
+    metronome: { transferAllowed },
+    converter: { status: converterStatus },
+    auction: { status: auctionStatus },
+    session: { isLoggedIn: true },
+    rates: { ETH: { token: 'ETH', price: 1 } },
+    wallets: {
+      active: 'foo',
+      allIds: ['foo'],
+      byId: {
+        foo: {
+          addresses: {
+            '0xf00': {
+              token: { [config.MTN_TOKEN_ADDR]: { balance: '1' } },
+              balance: '1'
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/components/__tests__/Dashboard.test.js
+++ b/src/components/__tests__/Dashboard.test.js
@@ -1,0 +1,217 @@
+import * as testUtils from '../../testUtils'
+import { Simulate } from 'react-testing-library'
+import Dashboard from '../Dashboard'
+import config from '../../config'
+import React from 'react'
+import 'react-testing-library/extend-expect'
+
+const ACTIVE_ADDRESS = '0xf00'
+
+describe('<Dashboard/>', () => {
+  it('Displays active address in header', () => {
+    const { getByTestId } = testUtils.reduxRender(
+      <Dashboard />,
+      getInitialState()
+    )
+    expect(getByTestId('address')).toBeInTheDOM()
+    expect(getByTestId('address')).toHaveTextContent(ACTIVE_ADDRESS)
+  })
+
+  it('Displays active address ETH BALANCE', () => {
+    const { getByTestId } = testUtils.reduxRender(
+      <Dashboard />,
+      getInitialState()
+    )
+    expect(getByTestId('eth-balance')).toBeInTheDOM()
+    expect(getByTestId('eth-balance')).toHaveTextContent('0.05')
+  })
+
+  it('Displays active address ETH BALANCE in USD', () => {
+    const { getByTestId } = testUtils.reduxRender(
+      <Dashboard />,
+      getInitialState()
+    )
+    expect(getByTestId('eth-balance-usd')).toHaveTextContent('$5.00 (USD)')
+  })
+
+  it('Displays active address MET BALANCE', () => {
+    const { getByTestId } = testUtils.reduxRender(
+      <Dashboard />,
+      getInitialState()
+    )
+    expect(getByTestId('met-balance')).toHaveTextContent('0.025')
+  })
+
+  it('Displays the RECEIVE DRAWER when Receive button is clicked', () => {
+    const { queryByTestId, getByTestId } = testUtils.reduxRender(
+      <Dashboard />,
+      getInitialState()
+    )
+    const btn = testUtils.withDataset(getByTestId('receive-btn'), 'modal')
+    expect(queryByTestId('receive-drawer')).not.toBeInTheDOM()
+    Simulate.click(btn)
+    expect(queryByTestId('receive-drawer')).toBeInTheDOM()
+  })
+
+  it('Displays the SEND DRAWER when Send button is clicked', () => {
+    const { queryByTestId, getByTestId } = testUtils.reduxRender(
+      <Dashboard />,
+      getInitialState()
+    )
+    const btn = testUtils.withDataset(getByTestId('send-btn'), 'modal')
+    expect(queryByTestId('send-drawer')).not.toBeInTheDOM()
+    Simulate.click(btn)
+    expect(queryByTestId('send-drawer')).toBeInTheDOM()
+  })
+
+  describe('if the user has NO FUNDS', () => {
+    it('SEND button is disabled', () => {
+      const { queryByTestId, getByTestId } = testUtils.reduxRender(
+        <Dashboard />,
+        getInitialState({ ethBalance: '0', metBalance: '0' })
+      )
+      const btn = testUtils.withDataset(getByTestId('send-btn'), 'modal')
+      expect(queryByTestId('send-drawer')).not.toBeInTheDOM()
+      Simulate.click(btn)
+      expect(queryByTestId('send-drawer')).not.toBeInTheDOM()
+    })
+
+    it('SEND button shows a tooltip when hovered', () => {
+      const { getByTestId } = testUtils.reduxRender(
+        <Dashboard />,
+        getInitialState({ ethBalance: '0', metBalance: '0' })
+      )
+      expect(getByTestId('send-btn').getAttribute('data-rh')).toBe(
+        'You need some funds to send'
+      )
+    })
+  })
+
+  describe('if connectivity is lost', () => {
+    it('SEND button is disabled', () => {
+      const { queryByTestId, getByTestId, store } = testUtils.reduxRender(
+        <Dashboard />,
+        getInitialState()
+      )
+      store.dispatch(goOffline())
+      const btn = testUtils.withDataset(getByTestId('send-btn'), 'modal')
+      expect(queryByTestId('send-drawer')).not.toBeInTheDOM()
+      Simulate.click(btn)
+      expect(queryByTestId('send-drawer')).not.toBeInTheDOM()
+    })
+
+    it('SEND button shows a tooltip when hovered', () => {
+      const { getByTestId, store } = testUtils.reduxRender(
+        <Dashboard />,
+        getInitialState()
+      )
+      expect(getByTestId('send-btn').getAttribute('data-rh')).toBeNull()
+      store.dispatch(goOffline())
+      expect(getByTestId('send-btn').getAttribute('data-rh')).toBe(
+        "Can't send while offline"
+      )
+    })
+  })
+
+  describe('If there are transactions to display', () => {
+    it('displays the transactions list', () => {
+      const { queryByTestId } = testUtils.reduxRender(
+        <Dashboard />,
+        getInitialState({
+          transactions: [getDummyTransaction()]
+        })
+      )
+      expect(queryByTestId('notx-msg')).not.toBeInTheDOM()
+      expect(queryByTestId('tx-list')).toBeInTheDOM()
+    })
+  })
+
+  describe('If there are NO transactions to display', () => {
+    it('displays a message saying "No transactions"', () => {
+      const { getByTestId } = testUtils.reduxRender(
+        <Dashboard />,
+        getInitialState()
+      )
+      expect(getByTestId('notx-msg')).toBeInTheDOM()
+    })
+  })
+})
+
+function goOffline() {
+  return {
+    type: 'connectivity-state-changed',
+    payload: { ok: false }
+  }
+}
+
+function getInitialState({
+  metBalance = '25000000000000000',
+  ethBalance = '50000000000000000',
+  transactions = []
+} = {}) {
+  return {
+    connectivity: { isOnline: true },
+    blockchain: { height: 1 },
+    metronome: { transferAllowed: true },
+    converter: { status: null },
+    auction: { status: null },
+    session: { isLoggedIn: true },
+    rates: { ETH: { token: 'ETH', price: 100 } },
+    wallets: {
+      active: 'foo',
+      allIds: ['foo'],
+      byId: {
+        foo: {
+          addresses: {
+            [ACTIVE_ADDRESS]: {
+              token: {
+                [config.MTN_TOKEN_ADDR]: { balance: metBalance }
+              },
+              balance: ethBalance,
+              transactions
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+function getDummyTransaction() {
+  return {
+    meta: {
+      metronome: {},
+      tokens: {
+        '0xde806d6efd432cdee42573760682d99ededc1d89': {
+          event: 'Transfer',
+          processing: false,
+          value:
+            '0x000000000000000000000000000000000000000000000001e5b8fa8fe2ac0000'
+        }
+      }
+    },
+    receipt: {
+      blockHash:
+        '0x6fc6664565759e20bbbe62bc816cc2909c140ebd1d4f40c14d888ef18592e209',
+      blockNumber: 407574,
+      cumulativeGasUsed: 38484,
+      gasUsed: 38484,
+      transactionHash:
+        '0xb7762b4afd014e1539db551b0647973c9a54d0a0f3e0659fb01042f757b50144',
+      transactionIndex: 0
+    },
+    transaction: {
+      transactionIndex: 0,
+      blockNumber: 407574,
+      blockHash:
+        '0x6fc6664565759e20bbbe62bc816cc2909c140ebd1d4f40c14d888ef18592e209',
+      hash:
+        '0xb7762b4afd014e1539db551b0647973c9a54d0a0f3e0659fb01042f757b50144',
+      value: '0',
+      gasPrice: '5000000000',
+      gas: 76968,
+      from: '0x15dd2028C976beaA6668E286b496A518F457b5Cf',
+      to: '0xde806D6efD432CDeE42573760682D99eDEdC1d89'
+    }
+  }
+}

--- a/src/components/__tests__/GasEditor.test.js
+++ b/src/components/__tests__/GasEditor.test.js
@@ -1,0 +1,95 @@
+import { Simulate } from 'react-testing-library'
+import * as testUtils from '../../testUtils'
+import GasEditor from '../GasEditor'
+import React from 'react'
+
+const element = (
+  <GasEditor
+    useCustomGas
+    onChange={jest.fn()}
+    gasLimit="21000"
+    gasPrice="1"
+    errors={{}}
+  />
+)
+
+describe('<GasEditor/>', () => {
+  it('should match its snapshot', () => {
+    const { container } = testUtils.reduxRender(element)
+    expect(container).toMatchSnapshot()
+  })
+})
+
+export function runValidateTests(element, initialState, formTestId) {
+  it('displays an error if GAS LIMIT is not provided', () => {
+    const { getByTestId } = testUtils.reduxRender(element, initialState)
+    Simulate.click(getByTestId('edit-gas-btn'))
+    testUtils.testValidation(getByTestId, formTestId, {
+      formData: { 'gas-limit-field': '' },
+      errors: { 'gas-limit-field': 'Gas limit is required' }
+    })
+  })
+
+  it('displays an error if GAS LIMIT is an invalid value', () => {
+    const { getByTestId } = testUtils.reduxRender(element, initialState)
+    Simulate.click(getByTestId('edit-gas-btn'))
+    testUtils.testValidation(getByTestId, formTestId, {
+      formData: { 'gas-limit-field': 'foo' },
+      errors: { 'gas-limit-field': 'Invalid value' }
+    })
+  })
+
+  it('displays an error if GAS LIMIT is not an integer', () => {
+    const { getByTestId } = testUtils.reduxRender(element, initialState)
+    Simulate.click(getByTestId('edit-gas-btn'))
+    testUtils.testValidation(getByTestId, formTestId, {
+      formData: { 'gas-limit-field': '1.1' },
+      errors: { 'gas-limit-field': 'Gas limit must be an integer' }
+    })
+  })
+
+  it('displays an error if GAS LIMIT is negative', () => {
+    const { getByTestId } = testUtils.reduxRender(element, initialState)
+    Simulate.click(getByTestId('edit-gas-btn'))
+    testUtils.testValidation(getByTestId, formTestId, {
+      formData: { 'gas-limit-field': '-1' },
+      errors: { 'gas-limit-field': 'Gas limit must be greater than 0' }
+    })
+  })
+
+  it('displays an error if GAS PRICE is not provided', () => {
+    const { getByTestId } = testUtils.reduxRender(element, initialState)
+    Simulate.click(getByTestId('edit-gas-btn'))
+    testUtils.testValidation(getByTestId, formTestId, {
+      formData: { 'gas-price-field': '' },
+      errors: { 'gas-price-field': 'Gas price is required' }
+    })
+  })
+
+  it('displays an error if GAS PRICE is an invalid value', () => {
+    const { getByTestId } = testUtils.reduxRender(element, initialState)
+    Simulate.click(getByTestId('edit-gas-btn'))
+    testUtils.testValidation(getByTestId, formTestId, {
+      formData: { 'gas-price-field': 'foo' },
+      errors: { 'gas-price-field': 'Invalid value' }
+    })
+  })
+
+  it('displays an error if GAS PRICE is negative', () => {
+    const { getByTestId } = testUtils.reduxRender(element, initialState)
+    Simulate.click(getByTestId('edit-gas-btn'))
+    testUtils.testValidation(getByTestId, formTestId, {
+      formData: { 'gas-price-field': '-1' },
+      errors: { 'gas-price-field': 'Gas price must be greater than 0' }
+    })
+  })
+
+  it('displays an error if GAS PRICE is not weiable', () => {
+    const { getByTestId } = testUtils.reduxRender(element, initialState)
+    Simulate.click(getByTestId('edit-gas-btn'))
+    testUtils.testValidation(getByTestId, formTestId, {
+      formData: { 'gas-price-field': '0.0000000000000000000000000000001' },
+      errors: { 'gas-price-field': 'Invalid value' }
+    })
+  })
+}

--- a/src/components/__tests__/ReceiveDrawer.test.js
+++ b/src/components/__tests__/ReceiveDrawer.test.js
@@ -1,0 +1,54 @@
+import * as testUtils from '../../testUtils'
+import ReceiveDrawer from '../ReceiveDrawer'
+import { Simulate } from 'react-testing-library'
+import React from 'react'
+import 'react-testing-library/extend-expect'
+
+const ACTIVE_ADDRESS = '0xf00'
+
+const element = <ReceiveDrawer onRequestClose={jest.fn()} isOpen />
+
+describe('<ReceiveDrawer/>', () => {
+  it('matches its snapshot', () => {
+    const { container } = testUtils.reduxRender(element, getInitialState())
+    expect(container.firstChild).toMatchSnapshot()
+  })
+
+  it('displays the active address', () => {
+    const { getByTestId } = testUtils.reduxRender(element, getInitialState())
+    expect(getByTestId('address')).toHaveTextContent(ACTIVE_ADDRESS)
+  })
+
+  it('displays a message when the Copy button is clicked and the address copied', () => {
+    const { getByTestId, queryByTestId } = testUtils.reduxRender(
+      element,
+      getInitialState()
+    )
+    expect(queryByTestId('btn-label')).toHaveTextContent('Copy')
+    Simulate.click(getByTestId('copy-btn'))
+    expect(queryByTestId('btn-label')).toHaveTextContent('Copied to clipboard!')
+  })
+})
+
+function getInitialState() {
+  return {
+    connectivity: { isOnline: true },
+    blockchain: { height: 1 },
+    metronome: { transferAllowed: true },
+    converter: { status: null },
+    auction: { status: null },
+    session: { isLoggedIn: true },
+    rates: { ETH: { token: 'ETH', price: 100 } },
+    wallets: {
+      active: 'foo',
+      allIds: ['foo'],
+      byId: {
+        foo: {
+          addresses: {
+            [ACTIVE_ADDRESS]: {}
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/components/__tests__/RecoverFromMnemonic.test.js
+++ b/src/components/__tests__/RecoverFromMnemonic.test.js
@@ -1,0 +1,43 @@
+import RecoverFromMnemonic from '../RecoverFromMnemonic'
+import * as testUtils from '../../testUtils'
+import { Simulate } from 'react-testing-library'
+import React from 'react'
+import 'react-testing-library/extend-expect'
+
+const element = <RecoverFromMnemonic />
+
+const VALID_MNEMONIC =
+  'discover prepare cause retire pitch web curious own hollow total initial simple'
+
+describe('<RecoverFromMnemonic/>', () => {
+  describe('When submitting the form', () => {
+    it('displays an error if MNEMONIC is not provided', () => {
+      const { getByTestId } = testUtils.routerRender(element)
+      testUtils.testValidation(getByTestId, 'recover-form', {
+        formData: { 'mnemonic-field': '' },
+        errors: { 'mnemonic-field': 'The phrase is required' }
+      })
+    })
+
+    it('displays an error if MNEMONIC is invalid', () => {
+      const { getByTestId } = testUtils.routerRender(element)
+      testUtils.testValidation(getByTestId, 'recover-form', {
+        formData: { 'mnemonic-field': 'foo' },
+        errors: {
+          'mnemonic-field':
+            "These words don't look like a valid recovery phrase"
+        }
+      })
+    })
+
+    it('displays the confirmation view if there are no errors', () => {
+      const { queryByTestId, getByTestId } = testUtils.routerRender(element)
+      expect(queryByTestId('confirmation')).not.toBeInTheDOM()
+      const mnemonicField = getByTestId('mnemonic-field')
+      mnemonicField.value = VALID_MNEMONIC
+      Simulate.change(mnemonicField)
+      Simulate.submit(getByTestId('recover-form'))
+      expect(queryByTestId('confirmation')).toBeInTheDOM()
+    })
+  })
+})

--- a/src/components/__tests__/Router.test.js
+++ b/src/components/__tests__/Router.test.js
@@ -1,9 +1,7 @@
 import { layout as element } from '../Router'
-import { MemoryRouter } from 'react-router'
 import * as testUtils from '../../testUtils'
 import { Simulate } from 'react-testing-library'
 import config from '../../config'
-import React from 'react'
 
 describe('<Router/>', () => {
   test('navigates to WALLET screen when clicking WALLET sidebar button', () => {
@@ -31,23 +29,24 @@ describe('<Router/>', () => {
   })
 
   test('redirects to WALLET route for / route', () => {
-    const { queryByTestId } = renderWithRouter('/')
+    const { queryByTestId } = testUtils.routerRender(
+      element,
+      getInitialState(),
+      '/'
+    )
     expect(queryByTestId('dashboard-container')).not.toBeNull()
   })
 })
 
 function clickAndExpect(linkTestId, pageTestId, initialRoute) {
-  const { getByTestId, queryByTestId } = renderWithRouter(initialRoute)
+  const { getByTestId, queryByTestId } = testUtils.routerRender(
+    element,
+    getInitialState(),
+    initialRoute
+  )
   expect(queryByTestId(pageTestId)).toBeNull()
   Simulate.click(getByTestId(linkTestId), { button: 0 })
   expect(queryByTestId(pageTestId)).not.toBeNull()
-}
-
-function renderWithRouter(initialRoute = '/') {
-  return testUtils.reduxRender(
-    <MemoryRouter initialEntries={[initialRoute]}>{element}</MemoryRouter>,
-    getInitialState()
-  )
 }
 
 function getInitialState() {

--- a/src/components/__tests__/SendDrawer.test.js
+++ b/src/components/__tests__/SendDrawer.test.js
@@ -1,0 +1,135 @@
+import * as testUtils from '../../testUtils'
+import { Simulate } from 'react-testing-library'
+import SendDrawer from '../SendDrawer'
+import config from '../../config'
+import React from 'react'
+import 'react-testing-library/extend-expect'
+
+const closeHandler = jest.fn()
+
+const getElement = defaultTab => (
+  <SendDrawer onRequestClose={closeHandler} defaultTab={defaultTab} isOpen />
+)
+
+describe('<SendDrawer/>', () => {
+  it('displays SEND ETH form when clicking the tab', () => {
+    const { queryByTestId, getByTestId } = testUtils.reduxRender(
+      getElement(),
+      getInitialState()
+    )
+    expect(queryByTestId('sendEth-form')).toBeNull()
+    Simulate.click(testUtils.withDataset(getByTestId('eth-tab'), 'tab'))
+    expect(queryByTestId('sendEth-form')).not.toBeNull()
+  })
+
+  it('displays SEND MET form when clicking the tab', () => {
+    const { queryByTestId, getByTestId } = testUtils.reduxRender(
+      getElement('eth'),
+      getInitialState()
+    )
+    expect(queryByTestId('sendMet-form')).toBeNull()
+    Simulate.click(testUtils.withDataset(getByTestId('met-tab'), 'tab'))
+    expect(queryByTestId('sendMet-form')).not.toBeNull()
+  })
+
+  describe('SEND MET tab is disabled and displays tooltip', () => {
+    it('if MET TRANSFERS ARE DISABLED ', () => {
+      const { queryByTestId, getByTestId } = testUtils.reduxRender(
+        getElement('eth'),
+        getInitialState({ transferAllowed: false })
+      )
+      Simulate.click(testUtils.withDataset(getByTestId('met-tab'), 'tab'))
+      expect(queryByTestId('sendMet-form')).not.toBeInTheDOM()
+      expect(getByTestId('met-tab').getAttribute('data-rh')).not.toBeNull()
+      expect(getByTestId('met-tab').getAttribute('data-rh')).toBe(
+        'MET transactions not enabled yet'
+      )
+    })
+
+    it('if we are on the INITIAL AUCTION ', () => {
+      const { queryByTestId, getByTestId } = testUtils.reduxRender(
+        getElement('eth'),
+        getInitialState({ isInitialAuction: true })
+      )
+      Simulate.click(testUtils.withDataset(getByTestId('met-tab'), 'tab'))
+      expect(queryByTestId('sendMet-form')).not.toBeInTheDOM()
+      expect(getByTestId('met-tab').getAttribute('data-rh')).not.toBeNull()
+      expect(getByTestId('met-tab').getAttribute('data-rh')).toBe(
+        'MET transactions are disabled during Initial Auction'
+      )
+    })
+
+    it('if user HAS NO MET', () => {
+      const { queryByTestId, getByTestId } = testUtils.reduxRender(
+        getElement('eth'),
+        getInitialState({ metBalance: '0' })
+      )
+      Simulate.click(testUtils.withDataset(getByTestId('met-tab'), 'tab'))
+      expect(queryByTestId('sendMet-form')).not.toBeInTheDOM()
+      expect(getByTestId('met-tab').getAttribute('data-rh')).not.toBeNull()
+      expect(getByTestId('met-tab').getAttribute('data-rh')).toBe(
+        'You need some MET to send'
+      )
+    })
+
+    it('if user IS OFFLINE', () => {
+      const { queryByTestId, getByTestId, store } = testUtils.reduxRender(
+        getElement('eth'),
+        getInitialState()
+      )
+      expect(getByTestId('met-tab').getAttribute('data-rh')).toBeNull()
+      store.dispatch(goOffline())
+      expect(getByTestId('met-tab').getAttribute('data-rh')).not.toBeNull()
+      Simulate.click(testUtils.withDataset(getByTestId('met-tab'), 'tab'))
+      expect(queryByTestId('sendMet-form')).not.toBeInTheDOM()
+      expect(getByTestId('met-tab').getAttribute('data-rh')).toBe(
+        "Can't send while offline"
+      )
+    })
+  })
+})
+
+function goOffline() {
+  return {
+    type: 'connectivity-state-changed',
+    payload: { ok: false }
+  }
+}
+
+function getInitialState({
+  transferAllowed = true,
+  isInitialAuction = false,
+  metBalance = '5000000000000000000000'
+} = {}) {
+  return {
+    connectivity: { isOnline: true },
+    blockchain: { height: 1 },
+    metronome: { transferAllowed },
+    converter: {
+      status: null
+    },
+    auction: {
+      status: {
+        currentAuction: isInitialAuction ? '0' : '1'
+      }
+    },
+    session: { isLoggedIn: true },
+    rates: { ETH: { token: 'ETH', price: 250 } },
+    wallets: {
+      active: 'foo',
+      allIds: ['foo'],
+      byId: {
+        foo: {
+          addresses: {
+            '0xf00': {
+              token: {
+                [config.MTN_TOKEN_ADDR]: { balance: metBalance }
+              },
+              balance: '5000000000000000000000'
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/components/__tests__/SendETHForm.test.js
+++ b/src/components/__tests__/SendETHForm.test.js
@@ -1,0 +1,88 @@
+import * as amountFields from './AmountFields.test.js'
+import * as gasEditor from './GasEditor.test.js'
+import * as testUtils from '../../testUtils'
+import { Simulate } from 'react-testing-library'
+import SendETHForm from '../SendETHForm'
+import config from '../../config'
+import React from 'react'
+
+const element = <SendETHForm />
+
+const ETHprice = 250
+
+const VALID_ADDRESS = '0xD6758d1907Ed647605429d40cd19C58A6d05Eb8b'
+
+describe('<SendETHForm/>', () => {
+  it('should match its snapshot', () => {
+    const { container } = testUtils.reduxRender(element, getInitialState())
+    expect(container).toMatchSnapshot()
+  })
+
+  describe('When editing the amount fields', () => {
+    amountFields.runEditTests(element, getInitialState(), ETHprice)
+  })
+
+  describe('When submitting the form', () => {
+    it('displays an error if ADDRESS is not provided', () => {
+      const { getByTestId } = testUtils.reduxRender(element, getInitialState())
+      testUtils.testValidation(getByTestId, 'sendEth-form', {
+        formData: { 'toAddress-field': '' },
+        errors: { 'toAddress-field': 'Address is required' }
+      })
+    })
+
+    it('displays an error if ADDRESS is invalid', () => {
+      const { getByTestId } = testUtils.reduxRender(element, getInitialState())
+      testUtils.testValidation(getByTestId, 'sendEth-form', {
+        formData: { 'toAddress-field': 'foo' },
+        errors: { 'toAddress-field': 'Invalid address' }
+      })
+    })
+
+    amountFields.runValidateTests(element, getInitialState(), 'sendEth-form')
+
+    gasEditor.runValidateTests(element, getInitialState(), 'sendEth-form')
+
+    it('displays the confirmation view if there are no errors', () => {
+      const { queryByTestId, getByTestId } = testUtils.reduxRender(
+        element,
+        getInitialState()
+      )
+      expect(queryByTestId('confirmation')).toBeNull()
+      const addressField = getByTestId('toAddress-field')
+      addressField.value = VALID_ADDRESS
+      Simulate.change(addressField)
+      const amountField = getByTestId('ethAmount-field')
+      amountField.value = '1'
+      Simulate.change(amountField)
+      Simulate.submit(getByTestId('sendEth-form'))
+      expect(queryByTestId('confirmation')).not.toBeNull()
+    })
+  })
+})
+
+function getInitialState() {
+  return {
+    connectivity: { isOnline: true },
+    blockchain: { height: 1 },
+    metronome: { transferAllowed: true },
+    converter: { status: null },
+    auction: { status: null },
+    session: { isLoggedIn: true },
+    rates: { ETH: { token: 'ETH', price: ETHprice } },
+    wallets: {
+      active: 'foo',
+      allIds: ['foo'],
+      byId: {
+        foo: {
+          addresses: {
+            '0xf00': {
+              token: { [config.MTN_TOKEN_ADDR]: { balance: '0' } },
+              balance: '5000000000000000000000'
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/components/__tests__/SendMETForm.test.js
+++ b/src/components/__tests__/SendMETForm.test.js
@@ -1,0 +1,100 @@
+import * as amountFields from './AmountFields.test.js'
+import * as gasEditor from './GasEditor.test.js'
+import * as testUtils from '../../testUtils'
+import { Simulate } from 'react-testing-library'
+import SendMETForm from '../SendMETForm'
+import config from '../../config'
+import React from 'react'
+
+const element = <SendMETForm />
+
+const ETHprice = 250
+
+const VALID_ADDRESS = '0xD6758d1907Ed647605429d40cd19C58A6d05Eb8b'
+
+describe('<SendMETForm/>', () => {
+  it('should match its snapshot', () => {
+    const { container } = testUtils.reduxRender(element, getInitialState())
+    expect(container).toMatchSnapshot()
+  })
+
+  describe('When editing the amount field', () => {
+    it('updates MET field when MAX button is clicked', () => {
+      const { getByTestId } = testUtils.reduxRender(element, getInitialState())
+      const metField = getByTestId('metAmount-field')
+      Simulate.click(getByTestId('max-btn'))
+      expect(metField.value).toBe('5000')
+    })
+  })
+
+  describe('When submitting the form', () => {
+    it('displays an error if ADDRESS is not provided', () => {
+      const { getByTestId } = testUtils.reduxRender(element, getInitialState())
+      testUtils.testValidation(getByTestId, 'sendMet-form', {
+        formData: { 'toAddress-field': '' },
+        errors: { 'toAddress-field': 'Address is required' }
+      })
+    })
+
+    it('displays an error if ADDRESS is invalid', () => {
+      const { getByTestId } = testUtils.reduxRender(element, getInitialState())
+      testUtils.testValidation(getByTestId, 'sendMet-form', {
+        formData: { 'toAddress-field': 'foo' },
+        errors: { 'toAddress-field': 'Invalid address' }
+      })
+    })
+
+    amountFields.runValidateTests(
+      element,
+      getInitialState(),
+      'sendMet-form',
+      'metAmount-field'
+    )
+
+    gasEditor.runValidateTests(element, getInitialState(), 'sendMet-form')
+
+    it('displays the confirmation view if there are no errors', () => {
+      const { queryByTestId, getByTestId } = testUtils.reduxRender(
+        element,
+        getInitialState()
+      )
+      expect(queryByTestId('confirmation')).toBeNull()
+      const addressField = getByTestId('toAddress-field')
+      addressField.value = VALID_ADDRESS
+      Simulate.change(addressField)
+      const amountField = getByTestId('metAmount-field')
+      amountField.value = '1'
+      Simulate.change(amountField)
+      Simulate.submit(getByTestId('sendMet-form'))
+      expect(queryByTestId('confirmation')).not.toBeNull()
+    })
+  })
+})
+
+function getInitialState() {
+  return {
+    connectivity: { isOnline: true },
+    blockchain: { height: 1 },
+    metronome: { transferAllowed: true },
+    converter: { status: null },
+    auction: { status: null },
+    session: { isLoggedIn: true },
+    rates: { ETH: { token: 'ETH', price: ETHprice } },
+    wallets: {
+      active: 'foo',
+      allIds: ['foo'],
+      byId: {
+        foo: {
+          addresses: {
+            '0xf00': {
+              token: {
+                [config.MTN_TOKEN_ADDR]: { balance: '5000000000000000000000' }
+              },
+              balance: '5000000000000000000000'
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/components/__tests__/TxList.test.js
+++ b/src/components/__tests__/TxList.test.js
@@ -1,0 +1,86 @@
+import * as testUtils from '../../testUtils'
+import { Simulate } from 'react-testing-library'
+import TxList from '../TxList'
+import config from '../../config'
+import React from 'react'
+import 'react-testing-library/extend-expect'
+
+const ACTIVE_ADDRESS = '0xf00'
+
+describe('<TxList/>', () => {
+  it('displays the receipt when clicking a transaction', () => {
+    const { queryByTestId, getByTestId } = testUtils.reduxRender(
+      <TxList />,
+      getInitialState()
+    )
+    expect(getByTestId('tx-row')).toBeInTheDOM()
+    expect(queryByTestId('receipt-modal')).not.toBeInTheDOM()
+    const txRow = testUtils.withDataset(getByTestId('tx-row'), 'hash')
+    Simulate.click(txRow)
+    expect(queryByTestId('receipt-modal')).toBeInTheDOM()
+  })
+})
+
+function getInitialState({ transactions = [] } = {}) {
+  return {
+    connectivity: { isOnline: true },
+    blockchain: { height: 1 },
+    metronome: { transferAllowed: true },
+    converter: { status: null },
+    auction: { status: null },
+    session: { isLoggedIn: true },
+    rates: { ETH: { token: 'ETH', price: 100 } },
+    wallets: {
+      active: 'foo',
+      allIds: ['foo'],
+      byId: {
+        foo: {
+          addresses: {
+            [ACTIVE_ADDRESS]: {
+              token: {
+                [config.MTN_TOKEN_ADDR]: { balance: '25000000000000000' }
+              },
+              balance: '50000000000000000',
+              transactions: [getDummyTransaction()]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+function getDummyTransaction() {
+  return {
+    meta: {
+      metronome: {},
+      tokens: {
+        [config.MTN_TOKEN_ADDR]: {
+          event: 'Transfer',
+          processing: false,
+          value:
+            '0x000000000000000000000000000000000000000000000001e5b8fa8fe2ac0000'
+        }
+      }
+    },
+    receipt: {
+      blockHash: '0x1234567890abcdef',
+      blockNumber: 407574,
+      cumulativeGasUsed: 38484,
+      gasUsed: 38484,
+      transactionHash: '0x1234567890abcdef',
+      transactionIndex: 0
+    },
+    transaction: {
+      transactionIndex: 0,
+      blockNumber: 407574,
+      blockHash: '0x1234567890abcdef',
+      hash: '0x1234567890abcdef',
+      value: '0',
+      gasPrice: '5000000000',
+      gas: 76968,
+      from: '0x15dd2028C976beaA6668E286b496A518F457b5Cf',
+      to: '0xde806D6efD432CDeE42573760682D99eDEdC1d89'
+    }
+  }
+}

--- a/src/components/__tests__/__snapshots__/AmountFields.test.js.snap
+++ b/src/components/__tests__/__snapshots__/AmountFields.test.js.snap
@@ -1,0 +1,70 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<AmountFields/> should match its snapshot 1`] = `
+<div>
+  <div
+    class="sc-jKJlTe fkNCah"
+  >
+    <div
+      class="sc-ckVGcZ kvHIve"
+    >
+      <button
+        type="button"
+        class="sc-htpNat fdEoJm"
+        data-testid="max-btn"
+        tabindex="-1"
+      >
+        MAX
+      </button>
+      <div>
+        <label
+          class="sc-dnqmqq ilsafR"
+          for="ethAmount"
+        >
+          Amount (ETH)
+        </label>
+        <input
+          type="text"
+          class="sc-iwsKbI kZiHEX"
+          value=""
+          id="ethAmount"
+          data-testid="ethAmount-field"
+          placeholder="0.00"
+        />
+      </div>
+    </div>
+    <div
+      class="sc-hMqMXs dnTKXF"
+    >
+      <svg
+        class="sc-bxivhb hXQRLM"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M24 7.136v.96H1.642l4.464 4.464-.682.682-5.28-5.28a.475.475 0 0 1 0-.682L5.424 2l.682.682-4.464 4.464H24v-.01zM18.576 11.6l-.682.682 4.464 4.464H0v.96h22.358l-4.464 4.464.682.681 5.28-5.28a.475.475 0 0 0 0-.681l-5.28-5.29z"
+        />
+      </svg>
+    </div>
+    <div
+      class="sc-ckVGcZ kvHIve"
+    >
+      <div>
+        <label
+          class="sc-dnqmqq ilsafR"
+          for="usdAmount"
+        >
+          Amount (USD)
+        </label>
+        <input
+          type="text"
+          class="sc-iwsKbI kZiHEX"
+          value=""
+          id="usdAmount"
+          data-testid="usdAmount-field"
+          placeholder="0.00"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/__tests__/__snapshots__/ConvertETHtoMETForm.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ConvertETHtoMETForm.test.js.snap
@@ -69,40 +69,18 @@ exports[`<AmountFields/> should match its snapshot 1`] = `
 </div>
 `;
 
-exports[`<BuyMETDrawer/> should match its snapshot 1`] = `
+exports[`<ConvertETHtoMETForm/> should match its snapshot 1`] = `
 <div>
-  <header
-    class="sc-jTzLTM bbfTuz"
-  >
-    <h1
-      class="sc-fjdhpX gUwcgC"
-      data-testid="drawer-title"
-    >
-      Buy Metronome
-    </h1>
-    <button
-      class="sc-jzJRlG fzwWXa"
-      data-testid="drawer-close-btn"
-    >
-      <svg
-        class="sc-bxivhb hXQRLM"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M12 24C5.386 24 0 18.614 0 12S5.386 0 12 0s12 5.386 12 12-5.386 12-12 12zM12 .96C5.914.96.96 5.914.96 12c0 6.086 4.954 11.04 11.04 11.04 6.086 0 11.04-4.954 11.04-11.04C23.04 5.914 18.086.96 12 .96zm3.984 15.696L12 12.672l-3.984 3.984-.682-.682 3.984-3.984-3.984-3.984.682-.681L12 11.309l3.984-3.984.682.681-3.984 3.984 3.984 3.984-.682.682z"
-        />
-      </svg>
-    </button>
-  </header>
   <div
-    data-testid="buy-drawer"
+    class="sc-eNQAEJ hdurla"
   >
-    <form
-      novalidate=""
-      data-testid="buy-form"
+    <div
+      class="sc-hMqMXs dKMJsu"
     >
-      <div
-        class="sc-hMqMXs dKMJsu"
+      <form
+        data-testid="ethToMet-form"
+        novalidate=""
+        id="convertForm"
       >
         <div
           class="sc-jKJlTe fkNCah"
@@ -178,14 +156,14 @@ exports[`<BuyMETDrawer/> should match its snapshot 1`] = `
               class="sc-jKJlTe jGctBw"
             >
               <span
-                class="sc-kEYyzF ekxbwv"
+                class="sc-jAaTju fRTHaR"
               >
                 Gas Limit: 
                 2000000
                 (Units)
               </span>
               <span
-                class="sc-kEYyzF ekxbwv"
+                class="sc-jAaTju fRTHaR"
               >
                 Gas Price: 
                 1
@@ -202,18 +180,19 @@ exports[`<BuyMETDrawer/> should match its snapshot 1`] = `
             </button>
           </div>
         </div>
-      </div>
-      <div
-        class="sc-jDwBTQ kemwUK"
+      </form>
+    </div>
+    <div
+      class="sc-gPEVay iUpDMu"
+    >
+      <button
+        type="submit"
+        class="sc-bwzfXH emHLVs"
+        form="convertForm"
       >
-        <button
-          type="submit"
-          class="sc-bwzfXH emHLVs"
-        >
-          Review Buy
-        </button>
-      </div>
-    </form>
+        Review Convert
+      </button>
+    </div>
   </div>
 </div>
 `;

--- a/src/components/__tests__/__snapshots__/ConvertMETtoETHForm.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ConvertMETtoETHForm.test.js.snap
@@ -1,0 +1,210 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<AmountFields/> should match its snapshot 1`] = `
+<div>
+  <div
+    class="sc-jKJlTe fkNCah"
+  >
+    <div
+      class="sc-ckVGcZ kvHIve"
+    >
+      <button
+        type="button"
+        class="sc-htpNat fdEoJm"
+        data-testid="max-btn"
+        tabindex="-1"
+      >
+        MAX
+      </button>
+      <div>
+        <label
+          class="sc-dnqmqq ilsafR"
+          for="ethAmount"
+        >
+          Amount (ETH)
+        </label>
+        <input
+          type="text"
+          class="sc-iwsKbI kZiHEX"
+          value=""
+          id="ethAmount"
+          data-testid="ethAmount-field"
+          placeholder="0.00"
+        />
+      </div>
+    </div>
+    <div
+      class="sc-hMqMXs dnTKXF"
+    >
+      <svg
+        class="sc-bxivhb hXQRLM"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M24 7.136v.96H1.642l4.464 4.464-.682.682-5.28-5.28a.475.475 0 0 1 0-.682L5.424 2l.682.682-4.464 4.464H24v-.01zM18.576 11.6l-.682.682 4.464 4.464H0v.96h22.358l-4.464 4.464.682.681 5.28-5.28a.475.475 0 0 0 0-.681l-5.28-5.29z"
+        />
+      </svg>
+    </div>
+    <div
+      class="sc-ckVGcZ kvHIve"
+    >
+      <div>
+        <label
+          class="sc-dnqmqq ilsafR"
+          for="usdAmount"
+        >
+          Amount (USD)
+        </label>
+        <input
+          type="text"
+          class="sc-iwsKbI kZiHEX"
+          value=""
+          id="usdAmount"
+          data-testid="usdAmount-field"
+          placeholder="0.00"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<ConvertMETtoETHForm/> should match its snapshot 1`] = `
+<div>
+  <div
+    class="sc-eNQAEJ hdurla"
+  >
+    <div
+      class="sc-hMqMXs dKMJsu"
+    >
+      <form
+        data-testid="metToEth-form"
+        novalidate=""
+        id="convertForm"
+      >
+        <div>
+          <button
+            type="button"
+            class="sc-htpNat fdEoJm"
+            data-testid="max-btn"
+            tabindex="-1"
+          >
+            MAX
+          </button>
+          <div>
+            <label
+              class="sc-dnqmqq ilsafR"
+              for="metAmount"
+            >
+              Amount (MET)
+            </label>
+            <input
+              type="text"
+              class="sc-iwsKbI kZiHEX"
+              value=""
+              id="metAmount"
+              placeholder="0.00"
+              data-testid="metAmount-field"
+            />
+          </div>
+          <div
+            class="sc-hMqMXs bQjXee"
+          >
+            <div
+              class="sc-jKJlTe kWLJKD"
+            >
+              <div
+                class="sc-jKJlTe jGctBw"
+              >
+                <span
+                  class="sc-jAaTju fRTHaR"
+                >
+                  Gas Limit: 
+                  2000000
+                  (Units)
+                </span>
+                <span
+                  class="sc-jAaTju fRTHaR"
+                >
+                  Gas Price: 
+                  1
+                  (Gwei)
+                </span>
+              </div>
+              <button
+                type="button"
+                class="sc-htpNat henWpP"
+                data-testid="edit-gas-btn"
+                tabindex="-1"
+              >
+                EDIT GAS
+              </button>
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div
+      class="sc-gPEVay iUpDMu"
+    >
+      <button
+        type="submit"
+        class="sc-bwzfXH emHLVs"
+        form="convertForm"
+      >
+        Review Convert
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<GasEditor/> should match its snapshot 1`] = `
+<div>
+  <div
+    class="sc-jKJlTe fkNCah"
+  >
+    <div
+      class="sc-ckVGcZ kvHIve"
+    >
+      <div>
+        <label
+          class="sc-dnqmqq ilsafR"
+          for="gasLimit"
+        >
+          Gas Limit (Units)
+        </label>
+        <input
+          type="text"
+          class="sc-iwsKbI kZiHEX"
+          value="21000"
+          id="gasLimit"
+          data-testid="gas-limit-field"
+        />
+      </div>
+    </div>
+    <div
+      class="sc-hMqMXs keWZLk"
+    />
+    <div
+      class="sc-ckVGcZ kvHIve"
+    >
+      <div>
+        <label
+          class="sc-dnqmqq ilsafR"
+          for="gasPrice"
+        >
+          Gas Price (Gwei)
+        </label>
+        <input
+          type="text"
+          class="sc-iwsKbI kZiHEX"
+          value="1"
+          id="gasPrice"
+          data-testid="gas-price-field"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/__tests__/__snapshots__/GasEditor.test.js.snap
+++ b/src/components/__tests__/__snapshots__/GasEditor.test.js.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<GasEditor/> should match its snapshot 1`] = `
+<div>
+  <div
+    class="sc-jKJlTe fkNCah"
+  >
+    <div
+      class="sc-ckVGcZ kvHIve"
+    >
+      <div>
+        <label
+          class="sc-dnqmqq ilsafR"
+          for="gasLimit"
+        >
+          Gas Limit (Units)
+        </label>
+        <input
+          type="text"
+          class="sc-iwsKbI kZiHEX"
+          value="21000"
+          id="gasLimit"
+          data-testid="gas-limit-field"
+        />
+      </div>
+    </div>
+    <div
+      class="sc-hMqMXs keWZLk"
+    />
+    <div
+      class="sc-ckVGcZ kvHIve"
+    >
+      <div>
+        <label
+          class="sc-dnqmqq ilsafR"
+          for="gasPrice"
+        >
+          Gas Price (Gwei)
+        </label>
+        <input
+          type="text"
+          class="sc-iwsKbI kZiHEX"
+          value="1"
+          id="gasPrice"
+          data-testid="gas-price-field"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/__tests__/__snapshots__/ReceiveDrawer.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ReceiveDrawer.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ReceiveDrawer/> matches its snapshot 1`] = `
+<header
+  class="sc-jTzLTM bbfTuz"
+>
+  <h1
+    class="sc-fjdhpX gUwcgC"
+    data-testid="drawer-title"
+  >
+    Receive Transaction
+  </h1>
+  <button
+    class="sc-jzJRlG fzwWXa"
+    data-testid="drawer-close-btn"
+  >
+    <svg
+      class="sc-bxivhb hXQRLM"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M12 24C5.386 24 0 18.614 0 12S5.386 0 12 0s12 5.386 12 12-5.386 12-12 12zM12 .96C5.914.96.96 5.914.96 12c0 6.086 4.954 11.04 11.04 11.04 6.086 0 11.04-4.954 11.04-11.04C23.04 5.914 18.086.96 12 .96zm3.984 15.696L12 12.672l-3.984 3.984-.682-.682 3.984-3.984-3.984-3.984.682-.681L12 11.309l3.984-3.984.682.681-3.984 3.984 3.984 3.984-.682.682z"
+      />
+    </svg>
+  </button>
+</header>
+`;

--- a/src/components/__tests__/__snapshots__/SendETHForm.test.js.snap
+++ b/src/components/__tests__/__snapshots__/SendETHForm.test.js.snap
@@ -1,0 +1,268 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<AmountFields/> should match its snapshot 1`] = `
+<div>
+  <div
+    class="sc-jKJlTe fkNCah"
+  >
+    <div
+      class="sc-ckVGcZ kvHIve"
+    >
+      <button
+        type="button"
+        class="sc-htpNat fdEoJm"
+        data-testid="max-btn"
+        tabindex="-1"
+      >
+        MAX
+      </button>
+      <div>
+        <label
+          class="sc-dnqmqq ilsafR"
+          for="ethAmount"
+        >
+          Amount (ETH)
+        </label>
+        <input
+          type="text"
+          class="sc-iwsKbI kZiHEX"
+          value=""
+          id="ethAmount"
+          data-testid="ethAmount-field"
+          placeholder="0.00"
+        />
+      </div>
+    </div>
+    <div
+      class="sc-hMqMXs dnTKXF"
+    >
+      <svg
+        class="sc-bxivhb hXQRLM"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M24 7.136v.96H1.642l4.464 4.464-.682.682-5.28-5.28a.475.475 0 0 1 0-.682L5.424 2l.682.682-4.464 4.464H24v-.01zM18.576 11.6l-.682.682 4.464 4.464H0v.96h22.358l-4.464 4.464.682.681 5.28-5.28a.475.475 0 0 0 0-.681l-5.28-5.29z"
+        />
+      </svg>
+    </div>
+    <div
+      class="sc-ckVGcZ kvHIve"
+    >
+      <div>
+        <label
+          class="sc-dnqmqq ilsafR"
+          for="usdAmount"
+        >
+          Amount (USD)
+        </label>
+        <input
+          type="text"
+          class="sc-iwsKbI kZiHEX"
+          value=""
+          id="usdAmount"
+          data-testid="usdAmount-field"
+          placeholder="0.00"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<GasEditor/> should match its snapshot 1`] = `
+<div>
+  <div
+    class="sc-jKJlTe fkNCah"
+  >
+    <div
+      class="sc-ckVGcZ kvHIve"
+    >
+      <div>
+        <label
+          class="sc-dnqmqq ilsafR"
+          for="gasLimit"
+        >
+          Gas Limit (Units)
+        </label>
+        <input
+          type="text"
+          class="sc-iwsKbI kZiHEX"
+          value="21000"
+          id="gasLimit"
+          data-testid="gas-limit-field"
+        />
+      </div>
+    </div>
+    <div
+      class="sc-hMqMXs keWZLk"
+    />
+    <div
+      class="sc-ckVGcZ kvHIve"
+    >
+      <div>
+        <label
+          class="sc-dnqmqq ilsafR"
+          for="gasPrice"
+        >
+          Gas Price (Gwei)
+        </label>
+        <input
+          type="text"
+          class="sc-iwsKbI kZiHEX"
+          value="1"
+          id="gasPrice"
+          data-testid="gas-price-field"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<SendETHForm/> should match its snapshot 1`] = `
+<div>
+  <div
+    class="sc-eNQAEJ hdurla"
+  >
+    <div
+      class="sc-hMqMXs dKMJsu"
+    >
+      <form
+        data-testid="sendEth-form"
+        novalidate=""
+        id="sendForm"
+      >
+        <div>
+          <label
+            class="sc-dnqmqq ilsafR"
+            for="toAddress"
+          >
+            Send to Address
+          </label>
+          <input
+            type="text"
+            class="sc-iwsKbI kZiHEX"
+            value=""
+            id="toAddress"
+            placeholder="e.g. 0x2345678998765434567"
+            data-testid="toAddress-field"
+          />
+        </div>
+        <div
+          class="sc-hMqMXs bQjXee"
+        >
+          <div
+            class="sc-jKJlTe fkNCah"
+          >
+            <div
+              class="sc-ckVGcZ kvHIve"
+            >
+              <button
+                type="button"
+                class="sc-htpNat fdEoJm"
+                data-testid="max-btn"
+                tabindex="-1"
+              >
+                MAX
+              </button>
+              <div>
+                <label
+                  class="sc-dnqmqq ilsafR"
+                  for="ethAmount"
+                >
+                  Amount (ETH)
+                </label>
+                <input
+                  type="text"
+                  class="sc-iwsKbI kZiHEX"
+                  value=""
+                  id="ethAmount"
+                  data-testid="ethAmount-field"
+                  placeholder="0.00"
+                />
+              </div>
+            </div>
+            <div
+              class="sc-hMqMXs dnTKXF"
+            >
+              <svg
+                class="sc-bxivhb hXQRLM"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M24 7.136v.96H1.642l4.464 4.464-.682.682-5.28-5.28a.475.475 0 0 1 0-.682L5.424 2l.682.682-4.464 4.464H24v-.01zM18.576 11.6l-.682.682 4.464 4.464H0v.96h22.358l-4.464 4.464.682.681 5.28-5.28a.475.475 0 0 0 0-.681l-5.28-5.29z"
+                />
+              </svg>
+            </div>
+            <div
+              class="sc-ckVGcZ kvHIve"
+            >
+              <div>
+                <label
+                  class="sc-dnqmqq ilsafR"
+                  for="usdAmount"
+                >
+                  Amount (USD)
+                </label>
+                <input
+                  type="text"
+                  class="sc-iwsKbI kZiHEX"
+                  value=""
+                  id="usdAmount"
+                  data-testid="usdAmount-field"
+                  placeholder="0.00"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="sc-hMqMXs bQjXee"
+        >
+          <div
+            class="sc-jKJlTe kWLJKD"
+          >
+            <div
+              class="sc-jKJlTe jGctBw"
+            >
+              <span
+                class="sc-kEYyzF ekxbwv"
+              >
+                Gas Limit: 
+                21000
+                (Units)
+              </span>
+              <span
+                class="sc-kEYyzF ekxbwv"
+              >
+                Gas Price: 
+                1
+                (Gwei)
+              </span>
+            </div>
+            <button
+              type="button"
+              class="sc-htpNat henWpP"
+              data-testid="edit-gas-btn"
+              tabindex="-1"
+            >
+              EDIT GAS
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div
+      class="sc-jAaTju dAcEaj"
+    >
+      <button
+        type="submit"
+        class="sc-bwzfXH emHLVs"
+        form="sendForm"
+      >
+        Review Send
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/__tests__/__snapshots__/SendMETForm.test.js.snap
+++ b/src/components/__tests__/__snapshots__/SendMETForm.test.js.snap
@@ -1,0 +1,228 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<AmountFields/> should match its snapshot 1`] = `
+<div>
+  <div
+    class="sc-jKJlTe fkNCah"
+  >
+    <div
+      class="sc-ckVGcZ kvHIve"
+    >
+      <button
+        type="button"
+        class="sc-htpNat fdEoJm"
+        data-testid="max-btn"
+        tabindex="-1"
+      >
+        MAX
+      </button>
+      <div>
+        <label
+          class="sc-dnqmqq ilsafR"
+          for="ethAmount"
+        >
+          Amount (ETH)
+        </label>
+        <input
+          type="text"
+          class="sc-iwsKbI kZiHEX"
+          value=""
+          id="ethAmount"
+          data-testid="ethAmount-field"
+          placeholder="0.00"
+        />
+      </div>
+    </div>
+    <div
+      class="sc-hMqMXs dnTKXF"
+    >
+      <svg
+        class="sc-bxivhb hXQRLM"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M24 7.136v.96H1.642l4.464 4.464-.682.682-5.28-5.28a.475.475 0 0 1 0-.682L5.424 2l.682.682-4.464 4.464H24v-.01zM18.576 11.6l-.682.682 4.464 4.464H0v.96h22.358l-4.464 4.464.682.681 5.28-5.28a.475.475 0 0 0 0-.681l-5.28-5.29z"
+        />
+      </svg>
+    </div>
+    <div
+      class="sc-ckVGcZ kvHIve"
+    >
+      <div>
+        <label
+          class="sc-dnqmqq ilsafR"
+          for="usdAmount"
+        >
+          Amount (USD)
+        </label>
+        <input
+          type="text"
+          class="sc-iwsKbI kZiHEX"
+          value=""
+          id="usdAmount"
+          data-testid="usdAmount-field"
+          placeholder="0.00"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<GasEditor/> should match its snapshot 1`] = `
+<div>
+  <div
+    class="sc-jKJlTe fkNCah"
+  >
+    <div
+      class="sc-ckVGcZ kvHIve"
+    >
+      <div>
+        <label
+          class="sc-dnqmqq ilsafR"
+          for="gasLimit"
+        >
+          Gas Limit (Units)
+        </label>
+        <input
+          type="text"
+          class="sc-iwsKbI kZiHEX"
+          value="21000"
+          id="gasLimit"
+          data-testid="gas-limit-field"
+        />
+      </div>
+    </div>
+    <div
+      class="sc-hMqMXs keWZLk"
+    />
+    <div
+      class="sc-ckVGcZ kvHIve"
+    >
+      <div>
+        <label
+          class="sc-dnqmqq ilsafR"
+          for="gasPrice"
+        >
+          Gas Price (Gwei)
+        </label>
+        <input
+          type="text"
+          class="sc-iwsKbI kZiHEX"
+          value="1"
+          id="gasPrice"
+          data-testid="gas-price-field"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<SendMETForm/> should match its snapshot 1`] = `
+<div>
+  <div
+    class="sc-eNQAEJ hdurla"
+  >
+    <div
+      class="sc-hMqMXs dKMJsu"
+    >
+      <form
+        data-testid="sendMet-form"
+        novalidate=""
+        id="sendForm"
+      >
+        <div>
+          <label
+            class="sc-dnqmqq ilsafR"
+            for="toAddress"
+          >
+            Send to Address
+          </label>
+          <input
+            type="text"
+            class="sc-iwsKbI kZiHEX"
+            value=""
+            id="toAddress"
+            placeholder="e.g. 0x2345678998765434567"
+            data-testid="toAddress-field"
+          />
+        </div>
+        <div
+          class="sc-hMqMXs bQjXee"
+        >
+          <button
+            type="button"
+            class="sc-htpNat fdEoJm"
+            data-testid="max-btn"
+            tabindex="-1"
+          >
+            MAX
+          </button>
+          <div>
+            <label
+              class="sc-dnqmqq ilsafR"
+              for="metAmount"
+            >
+              Amount (MET)
+            </label>
+            <input
+              type="text"
+              class="sc-iwsKbI kZiHEX"
+              value=""
+              id="metAmount"
+              placeholder="0.00"
+              data-testid="metAmount-field"
+            />
+          </div>
+        </div>
+        <div
+          class="sc-hMqMXs bQjXee"
+        >
+          <div
+            class="sc-jKJlTe kWLJKD"
+          >
+            <div
+              class="sc-jKJlTe jGctBw"
+            >
+              <span
+                class="sc-kEYyzF ekxbwv"
+              >
+                Gas Limit: 
+                2000000
+                (Units)
+              </span>
+              <span
+                class="sc-kEYyzF ekxbwv"
+              >
+                Gas Price: 
+                1
+                (Gwei)
+              </span>
+            </div>
+            <button
+              type="button"
+              class="sc-htpNat henWpP"
+              data-testid="edit-gas-btn"
+              tabindex="-1"
+            >
+              EDIT GAS
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div
+      class="sc-jAaTju dAcEaj"
+    >
+      <button
+        type="submit"
+        class="sc-bwzfXH emHLVs"
+        form="sendForm"
+      >
+        Review Send
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/common/Tabs.js
+++ b/src/components/common/Tabs.js
@@ -60,6 +60,7 @@ export default class Tabs extends React.Component {
       <Container>
         {items.map(({ label, id, disabled, ...other }) => (
           <Tab
+            data-testid={`${id}-tab`}
             isDisabled={disabled}
             isActive={active === id}
             data-tab={id}

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -10,3 +10,10 @@ global.window.require = function() {
     }
   }
 }
+
+/**
+ * react-modal uses Portals to append the modal node to the end of the document
+ * instead of the place where the <Modal /> component is placed, so we need to
+ * mock the package behavior and make it render the modal children in-place.
+ */
+jest.mock('react-modal', () => props => (props.isOpen ? props.children : null))

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -5,6 +5,9 @@ global.window.require = function() {
       send: jest.fn(),
       on: jest.fn()
     },
+    clipboard: {
+      writeText: jest.fn()
+    },
     shell: {
       openExternal: jest.fn()
     }

--- a/src/testUtils.js
+++ b/src/testUtils.js
@@ -1,5 +1,6 @@
 import { render, Simulate } from 'react-testing-library'
 import { ThemeProvider } from 'styled-components'
+import { MemoryRouter } from 'react-router'
 import { Provider } from 'react-redux'
 import createStore from './createStore'
 import theme from './theme'
@@ -26,6 +27,19 @@ export function reduxRender(element, initialState) {
     </Provider>
   )
   return { ...renderResult, store }
+}
+
+/**
+ * The same as reduxRender() above but also wrapped with 'react-router'
+ * in order to test navigation flows.
+ *
+ * Returns the same object as reduxRender()
+ */
+export function routerRender(element, initialState, initialRoute = '/') {
+  return reduxRender(
+    <MemoryRouter initialEntries={[initialRoute]}>{element}</MemoryRouter>,
+    initialState
+  )
 }
 
 /**


### PR DESCRIPTION
This will add UI tests for:

- Converter screen
- Convert ETH -> MET and MET -> ETH forms
- Wallet dashboard
- Receive transfer drawer
- Send ETH and Send MET forms
- Recover from mnemonic screen

Current reported coverage is around 83%.