### PR TITLE
Enforce and display EIP55 checksum addresses

### DIFF
--- a/src/components/DashboardHeader.js
+++ b/src/components/DashboardHeader.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types'
 import { Btn } from './common'
 import styled from 'styled-components'
 import React from 'react'
+import Web3 from 'web3'
 const { clipboard } = window.require('electron')
 
 const Container = styled.header`
@@ -105,8 +106,11 @@ class DashboardHeader extends React.Component {
   }
 }
 
-const mapStateToProps = state => ({
-  address: selectors.getActiveWalletAddresses(state)[0]
-})
+const mapStateToProps = state => {
+  const address = selectors.getActiveWalletAddresses(state)[0]
+  return {
+    address: address ? Web3.utils.toChecksumAddress(address) : address
+  }
+}
 
 export default connect(mapStateToProps)(DashboardHeader)

--- a/src/components/ReceiptModal.js
+++ b/src/components/ReceiptModal.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import config from '../config'
 import React from 'react'
+import Web3 from 'web3'
 const { shell } = window.require('electron')
 
 const Container = styled.div`
@@ -200,19 +201,23 @@ class ReceiptModal extends React.Component {
             </Type>
           </Row>
 
-          {tx.parsed.txType === 'received' && (
-            <Row>
-              <Label>{isPending ? 'Pending' : 'Received'} from</Label>
-              <Address>{tx.parsed.from}</Address>
-            </Row>
-          )}
+          {tx.parsed.txType === 'received' &&
+            tx.parsed.from && (
+              <Row>
+                <Label>{isPending ? 'Pending' : 'Received'} from</Label>
+                <Address>
+                  {Web3.utils.toChecksumAddress(tx.parsed.from)}
+                </Address>
+              </Row>
+            )}
 
-          {tx.parsed.txType === 'sent' && (
-            <Row>
-              <Label>{isPending ? 'Pending' : 'Sent'} to</Label>
-              <Address>{tx.parsed.to}</Address>
-            </Row>
-          )}
+          {tx.parsed.txType === 'sent' &&
+            tx.parsed.to && (
+              <Row>
+                <Label>{isPending ? 'Pending' : 'Sent'} to</Label>
+                <Address>{Web3.utils.toChecksumAddress(tx.parsed.to)}</Address>
+              </Row>
+            )}
 
           <Row>
             <Label>Confirmations</Label>

--- a/src/components/TxRow.js
+++ b/src/components/TxRow.js
@@ -6,6 +6,7 @@ import styled from 'styled-components'
 import config from '../config'
 import React from 'react'
 import theme from '../theme'
+import Web3 from 'web3'
 
 const Container = styled.div`
   margin-left: 1.6rem;
@@ -275,7 +276,7 @@ class TxRow extends React.Component {
                 {tx.txType === 'received' && (
                   <div>
                     {isPending ? 'Pending' : 'Received'} from{' '}
-                    <Address>{tx.from}</Address>
+                    <Address>{Web3.utils.toChecksumAddress(tx.from)}</Address>
                   </div>
                 )}
 
@@ -303,7 +304,7 @@ class TxRow extends React.Component {
                     ) : tx.to === config.CONVERTER_ADDR ? (
                       'CONVERTER CONTRACT'
                     ) : (
-                      <Address>{tx.to}</Address>
+                      <Address>{Web3.utils.toChecksumAddress(tx.to)}</Address>
                     )}
                   </div>
                 )}

--- a/src/components/__tests__/App.test.js
+++ b/src/components/__tests__/App.test.js
@@ -61,7 +61,7 @@ describe('<App/>', () => {
       payload: {
         foo: {
           addresses: {
-            '0xf00': {
+            '0x15dd2028C976beaA6668E286b496A518F457b5Cf': {
               token: { [config.MTN_TOKEN_ADDR]: { balance: '1' } },
               balance: '1'
             }

--- a/src/components/__tests__/Dashboard.test.js
+++ b/src/components/__tests__/Dashboard.test.js
@@ -5,7 +5,7 @@ import config from '../../config'
 import React from 'react'
 import 'react-testing-library/extend-expect'
 
-const ACTIVE_ADDRESS = '0xf00'
+const ACTIVE_ADDRESS = '0x15dd2028C976beaA6668E286b496A518F457b5Cf'
 
 describe('<Dashboard/>', () => {
   it('Displays active address in header', () => {

--- a/src/components/__tests__/Router.test.js
+++ b/src/components/__tests__/Router.test.js
@@ -64,7 +64,7 @@ function getInitialState() {
       byId: {
         foo: {
           addresses: {
-            '0xf00': {
+            '0x15dd2028C976beaA6668E286b496A518F457b5Cf': {
               token: { [config.MTN_TOKEN_ADDR]: { balance: '1' } },
               balance: '1'
             }

--- a/src/components/__tests__/SendETHForm.test.js
+++ b/src/components/__tests__/SendETHForm.test.js
@@ -39,6 +39,16 @@ describe('<SendETHForm/>', () => {
       })
     })
 
+    it('displays an error if ADDRESS CHECKSUM is invalid', () => {
+      const { getByTestId } = testUtils.reduxRender(element, getInitialState())
+      testUtils.testValidation(getByTestId, 'sendEth-form', {
+        formData: {
+          'toAddress-field': '0xd6758d1907Ed647605429d40cd19C58A6d05Eb8b'
+        },
+        errors: { 'toAddress-field': 'Address checksum is invalid' }
+      })
+    })
+
     amountFields.runValidateTests(element, getInitialState(), 'sendEth-form')
 
     gasEditor.runValidateTests(element, getInitialState(), 'sendEth-form')

--- a/src/components/__tests__/SendMETForm.test.js
+++ b/src/components/__tests__/SendMETForm.test.js
@@ -44,6 +44,16 @@ describe('<SendMETForm/>', () => {
       })
     })
 
+    it('displays an error if ADDRESS CHECKSUM is invalid', () => {
+      const { getByTestId } = testUtils.reduxRender(element, getInitialState())
+      testUtils.testValidation(getByTestId, 'sendMet-form', {
+        formData: {
+          'toAddress-field': '0xd6758d1907Ed647605429d40cd19C58A6d05Eb8b'
+        },
+        errors: { 'toAddress-field': 'Address checksum is invalid' }
+      })
+    })
+
     amountFields.runValidateTests(
       element,
       getInitialState(),

--- a/src/validator.js
+++ b/src/validator.js
@@ -28,8 +28,12 @@ export function validateMetAmount(mtnAmount, max, errors = {}) {
 export function validateToAddress(toAddress, errors = {}) {
   if (!toAddress) {
     errors.toAddress = 'Address is required'
-  } else if (!Web3.utils.isAddress(toAddress)) {
+    // Specifically check for address validity (ignoring checksum)
+  } else if (!Web3.utils.isAddress(toAddress.toLowerCase())) {
     errors.toAddress = 'Invalid address'
+    // Specifically check address checksum
+  } else if (!Web3.utils.checkAddressChecksum(toAddress)) {
+    errors.toAddress = 'Address checksum is invalid'
   }
 
   return errors


### PR DESCRIPTION
- check address checksum in "address" fields in "send" forms
- display only checksum'ed addresses (dashboard header, tx list and tx receipt)

Closes #258