### PR TITLE
Force restan txs on wallet recovery

### DIFF
--- a/public/main/plugins/ethWallet/index.js
+++ b/public/main/plugins/ethWallet/index.js
@@ -546,7 +546,16 @@ const createCreateWallet = (bus, plugins, plugin) =>
       return result
     }
 
-    openWallet({ bus, webContents, walletId: result.walletId, plugins, plugin })
+    setBestBlock({ number: -1 })
+      .then(function () {
+        openWallet({
+          bus,
+          webContents,
+          walletId: result.walletId,
+          plugins,
+          plugin
+        })
+      })
 
     return result
   }

--- a/public/main/settings/defaultSettings.json
+++ b/public/main/settings/defaultSettings.json
@@ -1,7 +1,7 @@
 {
   "app": {
-    "bestBlock": 2500000,
     "node": {
+    "bestBlock": 0,
       "jsonRpcApiUrl": "http://54.87.93.241:8545",
       "websocketApiUrl": "ws://54.87.93.241:8546"
     },


### PR DESCRIPTION
After a wallet is recovered, the best block is set to -1 to force the wallet to rescan all transactions associated with the recovered addresses.

Otherwise, no transactions would be recovered and the user might need to manually trigger a rescan.