### PR TITLE
Balance checks and other herbs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14951,6 +14951,23 @@
       "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
       "dev": true
     },
+    "startinterval2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/startinterval2/-/startinterval2-1.0.1.tgz",
+      "integrity": "sha512-lvJnEMpouysQ+fJ9jqO7dTW3YX9eD4LagSNF1Lg5k2JXbgSiV+F6BI9dCGiomCxBq5mcJbQM0ATGpVyCYLHLmA==",
+      "requires": {
+        "babel-polyfill": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.7"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+        }
+      }
+    },
     "stat-mode": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "reselect": "^3.0.1",
     "safe-buffer": "^5.1.1",
     "socket.io-client": "^2.0.4",
+    "startinterval2": "1.0.1",
     "styled-components": "^3.0.2",
     "supports-color": "^5.3.0",
     "tough-cookie": "^2.3.4",

--- a/public/main/plugins/ethWallet/index.js
+++ b/public/main/plugins/ethWallet/index.js
@@ -488,13 +488,13 @@ function openWallet ({ bus, webContents, walletId, plugins, plugin }) {
       })
     })
     .then(function () {
-      startInterval(function () {
-        const id = parseUnconfirmedTransactions(walletId, webContents)
-
-        bus.on('stop-searching-unconfirmed-txs', function () {
-          clearInterval(id)
-        })
+      const id = startInterval(function () {
+        parseUnconfirmedTransactions(walletId, webContents)
       }, rescanTime)
+
+      bus.on('stop-searching-unconfirmed-txs', function () {
+        clearInterval(id)
+      })
     })
 }
 

--- a/public/main/plugins/ethWallet/index.js
+++ b/public/main/plugins/ethWallet/index.js
@@ -187,8 +187,8 @@ function sendError ({ webContents, walletId, message, err }) {
   logger.warn(`<-- Error: ${message}`, { walletId, errMessage: err.message })
 }
 
-function sendBalances ({ walletId, webContents }) {
-  getWalletBalances(walletId)
+function sendBalances ({ shouldChange, walletId, webContents }) {
+  getWalletBalances(walletId, shouldChange)
     .then(function (balances) {
       balances.forEach(function ({ address, balance }) {
         sendWalletStateChange({
@@ -482,7 +482,11 @@ function parseNewTransaction (subscriptions, { walletId, txid }) {
           receipt,
           walletId
         }, s))
-          .then(() => sendBalances({ walletId, webContents: s.webContents }))
+          .then(() => sendBalances({
+            shouldChange: true,
+            walletId,
+            webContents: s.webContents
+          }))
       ))
     )
     .catch(function (err) {

--- a/public/main/plugins/ethWallet/index.js
+++ b/public/main/plugins/ethWallet/index.js
@@ -10,6 +10,7 @@ const pDefer = require('p-defer')
 const pRetry = require('p-retry')
 const promiseAllProps = require('promise-all-props')
 const settings = require('electron-settings')
+const startInterval = require('startinterval2')
 
 const { encrypt } = require('../../crypto/aes256cbcIv')
 const createBasePlugin = require('../../base-plugin')
@@ -26,6 +27,7 @@ const {
   clearDatabase
 } = require('./db')
 const {
+  getRescanUnconfirmedTxs,
   getWalletAddresses,
   isAddressInWallet
 } = require('./settings')
@@ -427,8 +429,43 @@ function syncTransactions ({ number, walletId, webContents, bloqEthExplorer }) {
     })
 }
 
+const getUnconfirmedTransactions = (projection = { 'transaction.hash': 1 }) =>
+  new Promise(function (resolve, reject) {
+    getDatabase().transactions
+      .find({ 'transaction.blockNumber': null }, projection)
+      .exec(function (err, transactions) {
+        if (err) {
+          reject(err)
+          return
+        }
+        resolve(transactions.map(t => t.transaction))
+      })
+  })
+
+function parseUnconfirmedTransactions (walletId, webContents) {
+  const web3 = getWeb3()
+
+  getUnconfirmedTransactions()
+    .then(transactions => transactions.map(t => t.hash))
+    .then(hashes =>
+      Promise.all(hashes.map(hash =>
+        getTransactionAndReceipt({ web3, hash })
+      ))
+    )
+    .then(fullTransactions =>
+      Promise.all(fullTransactions.map(t =>
+        parseTransaction(Object.assign({ walletId, webContents }, t))
+      ))
+    )
+    .catch(function (err) {
+      logger.warn(`Could not reparse unconfirmed transactions: ${err.message}`)
+    })
+}
+
 function openWallet ({ bus, webContents, walletId, plugins, plugin }) {
   const { bloqEthExplorer } = plugins
+
+  const rescanTime = getRescanUnconfirmedTxs()
 
   sendWalletOpen(bus, webContents, walletId)
 
@@ -450,10 +487,20 @@ function openWallet ({ bus, webContents, walletId, plugins, plugin }) {
         bus.removeListener('new-best-block', emitNewBlock)
       })
     })
+    .then(function () {
+      startInterval(function () {
+        const id = parseUnconfirmedTransactions(walletId, webContents)
+
+        bus.on('stop-searching-unconfirmed-txs', function () {
+          clearInterval(id)
+        })
+      }, rescanTime)
+    })
 }
 
 const stop = eventsBus => function () {
   eventsBus.emit('stop-updating-best-block')
+  eventsBus.emit('stop-searching-unconfirmed-txs')
 }
 
 function parseUnconfirmedTransaction (subscriptions, transaction) {

--- a/public/main/plugins/ethWallet/settings.js
+++ b/public/main/plugins/ethWallet/settings.js
@@ -51,10 +51,13 @@ function getJsonRpcApiUrl () {
 
 const getRescanBalance = () => settings.get('app.rescanBalance')
 
+const getRescanUnconfirmedTxs = () => settings.get('app.rescanUnconfirmedTxs')
+
 module.exports = {
   findWalletId,
   getJsonRpcApiUrl,
   getRescanBalance,
+  getRescanUnconfirmedTxs,
   getTracerApiUrl,
   getWallet,
   getWalletAddresses,

--- a/public/main/plugins/ethWallet/settings.js
+++ b/public/main/plugins/ethWallet/settings.js
@@ -49,9 +49,12 @@ function getJsonRpcApiUrl () {
   return settings.get('app.node.jsonRpcApiUrl')
 }
 
+const getRescanBalance = () => settings.get('app.rescanBalance')
+
 module.exports = {
   findWalletId,
   getJsonRpcApiUrl,
+  getRescanBalance,
   getTracerApiUrl,
   getWallet,
   getWalletAddresses,

--- a/public/main/plugins/ethWallet/wallet.js
+++ b/public/main/plugins/ethWallet/wallet.js
@@ -4,20 +4,43 @@ const logger = require('electron-log')
 
 const { getAddressBalance } = require('./eth')
 const { getWalletAddresses } = require('./settings')
-const { setAddressBalance } = require('./db')
+const db = require('./db')
 
-function getWalletBalances (walletId) {
+// util.promisify(setTimeout) is not yet possible in Electron 1.8.4
+// See https://github.com/electron/electron/issues/13654
+const setTimeoutAsync = delay => new Promise(function (resolve) {
+  setTimeout(resolve, delay)
+})
+
+function getWalletBalances (walletId, shouldChange) {
   return Promise.all(getWalletAddresses(walletId).map(function (address) {
-    return getAddressBalance(address).then(function (balance) {
-      setAddressBalance({ address, balance })
-        .then(function () {
-          logger.verbose(`Balance cached for ${address}: ${balance}`)
-        })
-        .catch(function (err) {
-          logger.warn(`Could not cache balance for ${address}: ${err.message}`)
-        })
-      return { address, balance }
-    })
+    return Promise.all([
+      getAddressBalance(address),
+      db.getAddressBalance({ address })
+    ])
+      .then(function ([balance, cached]) {
+        if (balance === cached && shouldChange) {
+          // Balance should have changed but did not, yet...
+          // Let's wait 15 sec and try again.
+          return setTimeoutAsync(15000)
+            .then(() => getAddressBalance(address))
+            .then(newBalance => ({ balance: newBalance, cached }))
+        }
+        return { balance, cached }
+      })
+      .then(function ({ balance, cached }) {
+        if (balance !== cached) {
+          db.setAddressBalance({ address, balance })
+            .then(function () {
+              logger.verbose(`Balance cached for ${address}: ${balance}`)
+            })
+            .catch(function (err) {
+              logger.warn(`Could not cache balance for ${address}: ${err.message}`)
+            })
+        }
+        return balance
+      })
+      .then(balance => ({ address, balance }))
   }))
 }
 

--- a/public/main/plugins/ethWallet/wallet.js
+++ b/public/main/plugins/ethWallet/wallet.js
@@ -3,8 +3,10 @@
 const logger = require('electron-log')
 
 const { getAddressBalance } = require('./eth')
-const { getWalletAddresses } = require('./settings')
+const { getRescanBalance, getWalletAddresses } = require('./settings')
 const db = require('./db')
+
+const rescanTime = getRescanBalance()
 
 // util.promisify(setTimeout) is not yet possible in Electron 1.8.4
 // See https://github.com/electron/electron/issues/13654
@@ -20,9 +22,8 @@ function getWalletBalances (walletId, shouldChange) {
     ])
       .then(function ([balance, cached]) {
         if (balance === cached && shouldChange) {
-          // Balance should have changed but did not, yet...
-          // Let's wait 15 sec and try again.
-          return setTimeoutAsync(15000)
+          // Balance should have changed but did not. Let's wait and try again.
+          return setTimeoutAsync(rescanTime)
             .then(() => getAddressBalance(address))
             .then(newBalance => ({ balance: newBalance, cached }))
         }

--- a/public/main/plugins/metronome/index.js
+++ b/public/main/plugins/metronome/index.js
@@ -2,6 +2,7 @@
 
 const createBasePlugin = require('../../base-plugin')
 
+const { getTokenAddress } = require('./settings')
 const createApi = require('./api')
 const sendStatus = require('./status')
 const transactionParser = require('./transactionParser')
@@ -27,7 +28,7 @@ const broadcastStatus = ethWallet => function (subscriptions) {
 }
 
 function init ({ plugins, eventsBus }) {
-  const { ethWallet } = plugins
+  const { ethWallet, tokens } = plugins
 
   ethWallet.registerTxParser(transactionParser(ethWallet))
 
@@ -62,6 +63,12 @@ function init ({ plugins, eventsBus }) {
   ])
 
   attachToEvents(eventsBus, plugins, plugin)
+
+  tokens.registerToken(getTokenAddress(), {
+    decimals: 18,
+    name: 'Metronome',
+    symbol: 'MET'
+  })
 
   return plugin
 }

--- a/public/main/plugins/tokens/api.js
+++ b/public/main/plugins/tokens/api.js
@@ -5,7 +5,11 @@ const logger = require('electron-log')
 
 const WalletError = require('../../WalletError')
 
-const { getTokenSymbol } = require('./settings')
+const {
+  addTokenContract,
+  getTokenContractAddresses,
+  getTokenSymbol
+} = require('./settings')
 const erc20Events = require('./erc20-events')
 const topicToAddress = require('./topic-to-address')
 
@@ -88,11 +92,20 @@ function createApi (ethWallet) {
     })
   }
 
+  function registerToken (address, meta) {
+    if (getTokenContractAddresses().includes(address)) {
+      return
+    }
+
+    addTokenContract(address, meta)
+  }
+
   return {
     approveToken,
     getAllowance,
-    sendToken,
-    getGasLimit
+    getGasLimit,
+    registerToken,
+    sendToken
   }
 }
 

--- a/public/main/plugins/tokens/balances.js
+++ b/public/main/plugins/tokens/balances.js
@@ -105,7 +105,6 @@ function sendBalances (params) {
   const web3 = ethWallet.getWeb3()
 
   const contracts = getTokenContractAddresses()
-    .map(a => a.toLowerCase())
     .map(address => ({
       contractAddress: address,
       contract: new web3.eth.Contract(abi, address),

--- a/public/main/plugins/tokens/balances.js
+++ b/public/main/plugins/tokens/balances.js
@@ -84,7 +84,7 @@ const getTokenBalanceOfAddress = shouldChange => function (params) {
       if (current === cached && shouldChange) {
         // Balance should have changed but did not. Let's wait and try again.
         return setTimeoutAsync(rescanTime)
-          .then(() => getTokenBalance({ address, contractAddress }))
+          .then(() => contract.methods.balanceOf(address).call())
           .then(function (newBalance) {
             cacheTokenBalance({ address, balance: newBalance, contractAddress })
             return newBalance

--- a/public/main/plugins/tokens/balances.js
+++ b/public/main/plugins/tokens/balances.js
@@ -3,20 +3,103 @@
 const abi = require('human-standard-token-abi')
 const logger = require('electron-log')
 
-const {
-  getTokenBalance,
-  setTokenBalance
-} = require('./db')
-const {
-  getTokenContractAddresses,
-  getTokenSymbol
-} = require('./settings')
+const { getTokenBalance, setTokenBalance } = require('./db')
+const { getTokenContractAddresses, getTokenSymbol } = require('./settings')
 
-function sendBalances ({ ethWallet, walletId, addresses, webContents }) {
-  const contractAddresses = getTokenContractAddresses()
+// util.promisify(setTimeout) is not yet possible in Electron 1.8.4
+// See https://github.com/electron/electron/issues/13654
+const setTimeoutAsync = delay => new Promise(function (resolve) {
+  setTimeout(resolve, delay)
+})
+
+function sendMessage (webContents, event, message) {
+  if (webContents.isDestroyed()) {
+    return
+  }
+
+  webContents.send(event, message)
+}
+
+const sendBalance = webContents => function (params) {
+  const { address, balance, contractAddress, symbol, walletId } = params
+
+  sendMessage(webContents, 'wallet-state-changed', {
+    [walletId]: {
+      addresses: {
+        [address]: {
+          token: {
+            [contractAddress]: {
+              symbol,
+              balance
+            }
+          }
+        }
+      }
+    }
+  })
+
+  logger.verbose(`<-- ${symbol} ${address} ${balance}`)
+}
+
+const sendError = webContents => function (err) {
+  logger.warn('Could not get or send token balance', err.message)
+
+  sendMessage(webContents, 'connectivity-state-changed', {
+    ok: false,
+    reason: 'Connection to Ethereum node failed',
+    plugin: 'tokens',
+    err: err.message
+  })
+}
+
+function cacheTokenBalance (params) {
+  const { address, balance, contractAddress } = params
+
+  logger.verbose('Caching token balance', address, contractAddress)
+
+  setTokenBalance({ address, contractAddress, balance })
+    .catch(function (err) {
+      logger.warn(`Could not save token balance: ${err.message}`)
+    })
+}
+
+const getTokenBalanceOfAddress = shouldChange => function (params) {
+  const { address, contractAddress, contract, symbol, walletId } = params
+
+  return Promise.all([
+    contract.methods.balanceOf(address).call().catch(err => ({ err })),
+    getTokenBalance({ address, contractAddress })
+  ])
+    .then(function ([current, cached]) {
+      if (current.err) {
+        return cached || Promise.reject(current.err)
+      }
+
+      if (current === cached && shouldChange) {
+        // Balance should have changed but did not, yet...
+        // Let's wait 15 sec and try again.
+        return setTimeoutAsync(15000)
+          .then(() => getTokenBalance({ address, contractAddress }))
+          .then(function (newBalance) {
+            cacheTokenBalance({ address, balance: newBalance, contractAddress })
+            return newBalance
+          })
+      }
+
+      cacheTokenBalance({ address, balance: current, contractAddress })
+      return current
+    })
+    .then(function (balance) {
+      return { address, balance, contractAddress, symbol, walletId }
+    })
+}
+
+function sendBalances (params) {
+  const { ethWallet, walletId, addresses, webContents, shouldChange } = params
 
   const web3 = ethWallet.getWeb3()
-  const contracts = contractAddresses
+
+  const contracts = getTokenContractAddresses()
     .map(a => a.toLowerCase())
     .map(address => ({
       contractAddress: address,
@@ -24,48 +107,15 @@ function sendBalances ({ ethWallet, walletId, addresses, webContents }) {
       symbol: getTokenSymbol(address)
     }))
 
-  addresses.map(a => a.toLowerCase()).forEach(function (address) {
-    contracts.forEach(function ({ contractAddress, contract, symbol }) {
-      contract.methods.balanceOf(address).call()
-        .then(function (balance) {
-          logger.verbose('Caching token balance', symbol)
-
-          return setTokenBalance({ address, contractAddress, balance })
-            .then(() => balance)
-        })
-        .catch(function (err) {
-          logger.warn('Could not get token balance', symbol, err.message)
-
-          return getTokenBalance({ address, contractAddress })
-        })
-        .then(function (balance) {
-          if (webContents.isDestroyed()) { return }
-
-          webContents.send('wallet-state-changed', {
-            [walletId]: {
-              addresses: {
-                [address]: {
-                  token: { [contractAddress]: { symbol, balance } }
-                }
-              }
-            }
-          })
-          logger.verbose(`<-- ${symbol} ${address} ${balance}`)
-        })
-        .catch(function (err) {
-          logger.warn('Could not send token balance', symbol, err.message)
-
-          if (webContents.isDestroyed()) { return }
-
-          webContents.send('connectivity-state-changed', {
-            ok: false,
-            reason: 'Connection to Ethereum node failed',
-            plugin: 'tokens',
-            err: err.message
-          })
-        })
-    })
-  })
+  addresses
+    .map(a => a.toLowerCase())
+    .map(address => contracts.map(c => Object.assign(c, { address, walletId })))
+    .reduce((flat, sub) => flat.concat(sub))
+    .map(getTokenBalanceOfAddress(shouldChange))
+    .map(promise => promise
+      .then(sendBalance(webContents))
+      .catch(sendError(webContents))
+    )
 }
 
 module.exports = sendBalances

--- a/public/main/plugins/tokens/balances.js
+++ b/public/main/plugins/tokens/balances.js
@@ -4,7 +4,13 @@ const abi = require('human-standard-token-abi')
 const logger = require('electron-log')
 
 const { getTokenBalance, setTokenBalance } = require('./db')
-const { getTokenContractAddresses, getTokenSymbol } = require('./settings')
+const {
+  getRescanBalance,
+  getTokenContractAddresses,
+  getTokenSymbol
+} = require('./settings')
+
+const rescanTime = getRescanBalance()
 
 // util.promisify(setTimeout) is not yet possible in Electron 1.8.4
 // See https://github.com/electron/electron/issues/13654
@@ -76,9 +82,8 @@ const getTokenBalanceOfAddress = shouldChange => function (params) {
       }
 
       if (current === cached && shouldChange) {
-        // Balance should have changed but did not, yet...
-        // Let's wait 15 sec and try again.
-        return setTimeoutAsync(15000)
+        // Balance should have changed but did not. Let's wait and try again.
+        return setTimeoutAsync(rescanTime)
           .then(() => getTokenBalance({ address, contractAddress }))
           .then(function (newBalance) {
             cacheTokenBalance({ address, balance: newBalance, contractAddress })

--- a/public/main/plugins/tokens/index.js
+++ b/public/main/plugins/tokens/index.js
@@ -53,6 +53,7 @@ function init ({ plugins, eventsBus }) {
     approveToken,
     getAllowance,
     getGasLimit,
+    registerToken,
     sendToken
   } = createApi(ethWallet)
 
@@ -66,7 +67,8 @@ function init ({ plugins, eventsBus }) {
   plugin.name = 'tokens'
   plugin.api = {
     approveToken,
-    getAllowance
+    getAllowance,
+    registerToken
   }
   plugin.dependencies = ['ethWallet']
   plugin.uiHooks.push(...[

--- a/public/main/plugins/tokens/index.js
+++ b/public/main/plugins/tokens/index.js
@@ -34,7 +34,13 @@ const broadcastBalances = ethWallet => function (subscriptions) {
   subscriptions.forEach(function ({ webContents, meta }) {
     const { walletId, addresses } = meta
 
-    sendBalances({ ethWallet, walletId, addresses, webContents })
+    sendBalances({
+      addresses,
+      ethWallet,
+      shouldChange: true,
+      walletId,
+      webContents
+    })
   })
 }
 

--- a/public/main/plugins/tokens/settings.js
+++ b/public/main/plugins/tokens/settings.js
@@ -12,7 +12,12 @@ const getTokenSymbol = address =>
 
 const getRescanBalance = () => settings.get('app.rescanBalance')
 
+function addTokenContract (address, meta) {
+  settings.set(`tokens.${address.toLowerCase()}`, meta)
+}
+
 module.exports = {
+  addTokenContract,
   getRescanBalance,
   getTokenContractAddresses,
   getTokenSymbol

--- a/public/main/plugins/tokens/settings.js
+++ b/public/main/plugins/tokens/settings.js
@@ -10,7 +10,10 @@ const getTokenContractAddresses = () =>
 const getTokenSymbol = address =>
   settings.get(`tokens.${address.toLowerCase()}.symbol`)
 
+const getRescanBalance = () => settings.get('app.rescanBalance')
+
 module.exports = {
+  getRescanBalance,
   getTokenContractAddresses,
   getTokenSymbol
 }

--- a/public/main/settings/defaultSettings.json
+++ b/public/main/settings/defaultSettings.json
@@ -15,12 +15,5 @@
   "coincap": {
     "ethPriceEmitRate": 5
   },
-  "tokens": {
-    "0xa3d58c4E56fedCae3a7c43A725aeE9A71F0ece4e": {
-      "decimals": 18,
-      "name": "Metronome",
-      "symbol": "MET"
-    }
-  },
   "settingsVersion": 15
 }

--- a/public/main/settings/defaultSettings.json
+++ b/public/main/settings/defaultSettings.json
@@ -9,7 +9,8 @@
     "indexerApiUrl": "https://indexer.metronome.io",
     "tracerApiUrl": "https://tracer.metronome.io",
     "trackingId": "UA-116275666-6",
-    "rescanBalance": 15000
+    "rescanBalance": 15000,
+    "rescanUnconfirmedTxs": 600000
   },
   "coincap": {
     "ethPriceEmitRate": 5

--- a/public/main/settings/defaultSettings.json
+++ b/public/main/settings/defaultSettings.json
@@ -8,7 +8,8 @@
     "defaultDerivationPath": "m/44'/60'/0'/0",
     "indexerApiUrl": "https://indexer.metronome.io",
     "tracerApiUrl": "https://tracer.metronome.io",
-    "trackingId": "UA-116275666-6"
+    "trackingId": "UA-116275666-6",
+    "rescanBalance": 15000
   },
   "coincap": {
     "ethPriceEmitRate": 5
@@ -20,5 +21,5 @@
       "symbol": "MET"
     }
   },
-  "settingsVersion": 14
+  "settingsVersion": 15
 }


### PR DESCRIPTION
- Retries getting balances in case the indexer is ahead of the public nodes.
- Rescans pending transactions on restart and on interval just in case something goes wrong and transactions keep in pending state.
- Automatically registers the MET token in the settings so it does no longer depends on the settings file.