### PR TITLE
Increase web3 calls timeout

### DIFF
--- a/public/config/index.js
+++ b/public/config/index.js
@@ -20,5 +20,6 @@ module.exports = {
   scanTransactionTimeout: 240000,
   sentryDsn: process.env.SENTRY_DSN,
   statePersistanceDebounce: 2000,
-  trackingId: process.env.TRACKING_ID
+  trackingId: process.env.TRACKING_ID,
+  web3Timeout: 120000
 }


### PR DESCRIPTION
This patch (commit) was successfully applied and tested in `master` as a quick-fix prior to release. Now needs to be applied to `develop` too.