### PR TITLE
Add notarization process to publishing Mac's dmg

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@
 
 ## Development
 
+Create a local `.env` file with the following content
+
+```shell
+ENABLED_CHAINS=
+ROPSTEN_NODE_URL=
+
+```
+
 ### Requirements
 
 * [Node.js](https://nodejs.org) LTS (v12 minimum, v14 recommended)
@@ -64,9 +72,44 @@ npm run dist
 npm run release
 ```
 
-To sign the macOS installers, execute `npm run dist:mac`.
-The signing certificate shall be in the root folder and be named `met.p12`.
-The certificate password will be required before signing.
+#### MacOs
+
+You'll need to sign and notarize the app. To do, install the `met.p12` file in your local keychain.  
+In addition to that, you'll have to set the following env variables in order to publish
+
+```shell
+# See below to complete these two fields
+APPLE_ID=
+APPLE_ID_PASSWORD=
+# See electron-build docs on how to complete these two
+CSC_LINK=
+CSC_KEY_PASSWORD=
+# Github token from your developer settings
+GH_TOKEN=
+```
+
+You'll need to follow [these steps to create an app specific password](https://support.apple.com/en-us/HT204397) and you'll set the generated value in `APPLE_ID_PASSWORD` together with your apple id in `APPLE_ID`.
+For the github token, create an access token with the `repo` permission. [Steps to create an access token here](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+
+The signing certificate shall be in the root folder and be named `met.p12`. They will also have to be in your keychain
+The certificate password will be required before signing.  
+Keep in mind that the process might take ~10 minutes because notarizing takes time.  
+You might be prompted your keychain password during the process in order to access the installed certificate.  
+
+To publish the application, run
+
+```shell
+npm run release
+```
+In order to verify that the application has been successfully sign and notarized, run
+
+```shell
+# Verifies the app has been signed
+codesign --verify --verbose ./dist/mac/Metronome\ Wallet.app
+
+# Verifies the app has been notarized
+spctl -a -t exec -vvv ./dist/mac/Metronome\ Wallet.app
+```
 
 ## License
 

--- a/entitlements.mac.plist
+++ b/entitlements.mac.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+  </dict>
+</plist>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8338,6 +8338,16 @@
       "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.3.0.tgz",
       "integrity": "sha512-iuJjH/ZEJkDyCbuAMvvFxAjCMDLMXIQ5NqvppETGrbtf4b/007r5P36BSvexdy0UzwDNzDtIuEXLR34vRXWZrg=="
     },
+    "electron-notarize": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-1.0.0.tgz",
+      "integrity": "sha512-dsib1IAquMn0onCrNMJ6gtEIZn/azG8hZMCYOuZIMVMUeRMgBYHK1s5TK9P8xAcrAjh/2aN5WYHzgVSWX314og==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.1"
+      }
+    },
     "electron-publish": {
       "version": "22.11.7",
       "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.11.7.tgz",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "electron": "13.1.4",
     "electron-builder": "22.11.7",
     "electron-devtools-installer": "3.2.0",
+    "electron-notarize": "1.0.0",
     "eslint-config-bloq": "2.4.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-config-standard": "16.0.3",
@@ -107,6 +108,7 @@
     "directories": {
       "buildResources": "assets"
     },
+    "afterSign": "scripts/notarize.js",
     "mac": {
       "artifactName": "${name}_v${version}.${ext}",
       "category": "public.app-category.finance",
@@ -114,7 +116,11 @@
       "extendInfo": {
         "NSUserNotificationAlertStyle": "alert"
       },
-      "electronUpdaterCompatibility": ">= 2.16"
+      "electronUpdaterCompatibility": ">= 2.16",
+      "hardenedRuntime": true,
+      "gatekeeperAssess": false,
+      "entitlements": "./entitlements.mac.plist",
+      "entitlementsInherit": "./entitlements.mac.plist"
     },
     "dmg": {
       "backgroundColor": "#7e61f8",
@@ -129,8 +135,7 @@
           "type": "link",
           "path": "/Applications"
         }
-      ],
-      "sign": true
+      ]
     },
     "linux": {
       "artifactName": "${name}_v${version}.${ext}",

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -1,0 +1,18 @@
+require('dotenv').config();
+const { notarize } = require('electron-notarize');
+
+exports.default = function notarizing(context) {
+  const { electronPlatformName, appOutDir } = context;  
+  if (electronPlatformName !== 'darwin') {
+    return;
+  }
+
+  const appName = context.packager.appInfo.productFilename;
+
+  return notarize({
+    appBundleId: 'sh.autonomous.metronome.wallet.desktop',
+    appPath: `${appOutDir}/${appName}.app`,
+    appleId: process.env.APPLE_ID,
+    appleIdPassword: process.env.APPLE_ID_PASSWORD,
+  });
+};


### PR DESCRIPTION
This PR adds the necessary changes to notarize the Application when building it for Mac.

`sign` had to be removed according to [this tutorial](https://kilianvalkhof.com/2019/electron/notarizing-your-electron-application/).

The [electron-notarize](https://github.com/electron/electron-notarize) is also relevant for this PR.