### PR TITLE
Add AS short name to the notarization process

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,11 @@
 
 ## Development
 
-Create a local `.env` file with the following content
+Create a local `.env` file with the following content:
 
 ```shell
 ENABLED_CHAINS=
 ROPSTEN_NODE_URL=
-
 ```
 
 ### Requirements
@@ -25,7 +24,7 @@ ROPSTEN_NODE_URL=
 
 ### Launch
 
-```bash
+```sh
 # Install dependencies
 npm i
 
@@ -35,10 +34,10 @@ npm run dev
 
 #### Troubleshooting
 
-- If you get an error when installing the dependencies related to `node-gyp`, try using `sudo` to postinstall the deps
-- For  windows, you might need to install the windows-build-tools. To do so, run 
+- For errors related to `node-gyp` when installing the dependencies, try using `sudo` to postinstall the dependencies.
+- For Windows, installing `windows-build-tools` may be required. To do so, run:
 
-```bash
+```sh
 npm i --global --production windows-build-tools
 ```
 
@@ -52,7 +51,7 @@ The log output is in the next directories:
 
 `process-type` being equal to `main`, `renderer` or `worker`
 
-More info [github.com/megahertz/electron-log](https://github.com/megahertz/electron-log)
+More info [github.com/megahertz/electron-log](https://github.com/megahertz/electron-log).
 
 ### Settings
 
@@ -64,52 +63,66 @@ To completely remove the application and start over, remove the settings file to
 
 ### Production Build
 
-```bash
+```sh
 # Run build process
 npm run dist
+
+# or
 
 # Run build process and publish to GitHub releases
 npm run release
 ```
 
-#### MacOs
+#### macOs
 
-You'll need to sign and notarize the app. To do, install the `met.p12` file in your local keychain.  
-In addition to that, you'll have to set the following env variables in order to publish
+The app needs to be signed and notarized.
+To do so, install the `.p12` file in the local keychain (double click on it).
 
-```shell
-# See below to complete these two fields
+The certificate is obtained from the Apple Developer website.
+The Developer ID Application is required.
+The Developer ID Installer may be required too.
+Once obtained, the `.cer` files have to be converted to `.p12` by providing the certificate passwords/private keys.
+
+In addition to that, the following environment variables have to be set to publish:
+
+```sh
+# See below to complete these two:
 APPLE_ID=
 APPLE_ID_PASSWORD=
-# See electron-build docs on how to complete these two
+# See `electron-build` docs on how to complete these two:
 CSC_LINK=
 CSC_KEY_PASSWORD=
-# Github token from your developer settings
+# Github personal access token to upload the files to repo releases.
 GH_TOKEN=
 ```
 
-You'll need to follow [these steps to create an app specific password](https://support.apple.com/en-us/HT204397) and you'll set the generated value in `APPLE_ID_PASSWORD` together with your apple id in `APPLE_ID`.
-For the github token, create an access token with the `repo` permission. [Steps to create an access token here](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+Follow [these steps to create an app specific password](https://support.apple.com/en-us/HT204397).
+The `APPLE_ID` variable is the Apple ID used to create the password.
+`APPLE_ID_PASSWORD` is the password Apple created for the app.
 
-The signing certificate shall be in the root folder and be named `met.p12`. They will also have to be in your keychain
-The certificate password will be required before signing.  
-Keep in mind that the process might take ~10 minutes because notarizing takes time.  
-You might be prompted your keychain password during the process in order to access the installed certificate.  
+The GitHub personal access token needs `repo` permissions.
+See the docs on [how to create a personal access access token](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) for more information.
 
-To publish the application, run
+The signing certificate shall be in the root folder of the repository.
+The certificate password will be required during the signing process.
+The signing process may take several minutes because notarization requieres uploading the app to Apple.
 
-```shell
-npm run release
-```
-In order to verify that the application has been successfully sign and notarized, run
+In order to verify that the application has been successfully signed and notarized, run:
 
-```shell
+```sh
 # Verifies the app has been signed
 codesign --verify --verbose ./dist/mac/Metronome\ Wallet.app
 
 # Verifies the app has been notarized
 spctl -a -t exec -vvv ./dist/mac/Metronome\ Wallet.app
 ```
+
+#### Windows
+
+To sign the application, a certificate for the Microsoft Authenticode platform is required.
+The certificate, a `.p7b` file, will then be required during the build process.
+
+Current provider is [DigiCert](https://www.digicert.com).
 
 ## License
 

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -14,5 +14,6 @@ exports.default = function notarizing(context) {
     appPath: `${appOutDir}/${appName}.app`,
     appleId: process.env.APPLE_ID,
     appleIdPassword: process.env.APPLE_ID_PASSWORD,
+    ascProvider: '99Y6CF5TBP'
   });
 };


### PR DESCRIPTION
This is required to build the app using Apple IDs that are linked to several organizations.

Actual effort: 1.5h